### PR TITLE
Disable clang-format option in libh3

### DIFF
--- a/h3ron-h3-sys/build.rs
+++ b/h3ron-h3-sys/build.rs
@@ -17,6 +17,7 @@ fn main() {
         .define("BUILD_GENERATORS", "OFF")
         .define("BUILD_TESTING", "OFF")
         .define("ENABLE_DOCS", "OFF")
+        .define("ENABLE_FORMAT", "OFF")
         .build();
 
 


### PR DESCRIPTION
Build fail when building `h3ron-h3-sys` as normal cargo dependency (1) when clang-format is installed.

We are strictly consuming `libh3`, so it makes no sense to be formatting its source code. Let's disable the format option altogether generating the Makefile.

1: building a locally checked-out copy of this repo works fine with the format option enabled.
