### PR TITLE
Added validity checks on `get_parent` and construction methods.

### DIFF
--- a/h3ron-h3-sys/build.rs
+++ b/h3ron-h3-sys/build.rs
@@ -2,11 +2,11 @@ extern crate bindgen;
 extern crate cmake;
 extern crate regex;
 
+use cmake::Config;
+use regex::Regex;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use cmake::Config;
-use regex::Regex;
 
 fn main() {
     // build h3ron as a static library
@@ -20,28 +20,39 @@ fn main() {
         .define("ENABLE_FORMAT", "OFF")
         .build();
 
-
     // link to the static library we just build
     println!("cargo:rustc-link-lib=static=h3");
-    println!("cargo:rustc-link-search=native={}", dst_path.join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst_path.join("lib").display()
+    );
 
     let header_path = dst_path.join("include/h3/h3api.h");
-    let mut builder = bindgen::Builder::default()
-        .header(dst_path.join("include/h3/h3api.h")
+    let mut builder = bindgen::Builder::default().header(
+        dst_path
+            .join("include/h3/h3api.h")
             .into_os_string()
             .into_string()
-            .expect("Path could not be converted to string"));
+            .expect("Path could not be converted to string"),
+    );
 
     // read the contents of the header to extract functions and types
     let header_contents = fs::read_to_string(header_path).expect("Unable to read h3 header");
-    for cap in Regex::new(r"H3_EXPORT\(\s*(?P<func>[a-zA-Z0-9_]+)\s*\)").unwrap().captures_iter(&header_contents) {
+    for cap in Regex::new(r"H3_EXPORT\(\s*(?P<func>[a-zA-Z0-9_]+)\s*\)")
+        .unwrap()
+        .captures_iter(&header_contents)
+    {
         builder = builder.whitelist_function(&cap["func"]);
     }
-    for cap in Regex::new(r"struct\s+\{[^\}]*}\s*(?P<type>[a-zA-Z0-9_]+)").unwrap().captures_iter(&header_contents) {
+    for cap in Regex::new(r"struct\s+\{[^\}]*}\s*(?P<type>[a-zA-Z0-9_]+)")
+        .unwrap()
+        .captures_iter(&header_contents)
+    {
         builder = builder.whitelist_type(&cap["type"]);
     }
     // Finish the builder and generate the bindings.
-    let bindings = builder.generate()
+    let bindings = builder
+        .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 

--- a/h3ron-ndarray/src/resolution.rs
+++ b/h3ron-ndarray/src/resolution.rs
@@ -50,7 +50,7 @@ pub fn nearest_h3_resolution(
         // calculate the area of the center index to avoid using the approximate values
         // of the h3ron hexArea functions
         let area_h3_index = area_linearring(
-            Index::from_coordinate(&center_of_array, h3_res)
+            Index::from_coordinate_unchecked(&center_of_array, h3_res)
                 .to_polygon()
                 .exterior(),
         );

--- a/h3ron/src/algorithm.rs
+++ b/h3ron/src/algorithm.rs
@@ -84,6 +84,7 @@ mod tests {
     #[test]
     fn smooth_donut_linked_polygon() {
         let ring = Index::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+            .unwrap()
             .hex_ring(4)
             .unwrap();
         let polygons = ring.to_linked_polygons(false);

--- a/h3ron/src/collections.rs
+++ b/h3ron/src/collections.rs
@@ -97,7 +97,10 @@ impl<'a> H3CompactedVec {
         }
         let mut index = Index::new(h3index);
         for r in index.resolution()..=H3_MIN_RESOLUTION {
-            index = index.get_parent(r);
+            index = match index.get_parent(r) {
+                Ok(i) => i,
+                Err(_) => continue,
+            };
             if self.indexes_by_resolution[r as usize].contains(&index.h3index()) {
                 return true;
             }
@@ -261,7 +264,8 @@ impl<'a> H3CompactedVec {
                 orig_h3indexes.drain(..).for_each(|h3index| {
                     let index = Index::new(h3index);
                     if !(lowest_res..r).any(|parent_res| {
-                        known_indexes.contains(&index.get_parent(parent_res as u8).h3index())
+                        known_indexes
+                            .contains(&index.get_parent_unchecked(parent_res as u8).h3index())
                     }) {
                         known_indexes.insert(h3index);
                         self.indexes_by_resolution[r].push(h3index);

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -180,8 +180,8 @@ pub fn line_between_indexes(start: H3Index, end: H3Index) -> Result<Vec<H3Index>
 pub fn line(linestring: &LineString<f64>, h3_resolution: u8) -> Result<Vec<H3Index>, Error> {
     let mut h3_indexes_out = vec![];
     for coords in linestring.0.windows(2) {
-        let start_index = Index::from_coordinate(&coords[0], h3_resolution);
-        let end_index = Index::from_coordinate(&coords[1], h3_resolution);
+        let start_index = Index::from_coordinate(&coords[0], h3_resolution)?;
+        let end_index = Index::from_coordinate(&coords[1], h3_resolution)?;
 
         let mut segment_indexes =
             line_between_indexes_not_checked(start_index.h3index(), end_index.h3index())?;

--- a/h3ron/src/to_geo.rs
+++ b/h3ron/src/to_geo.rs
@@ -202,6 +202,7 @@ mod tests {
     #[test]
     fn donut_linked_polygon() {
         let ring = Index::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+            .unwrap()
             .hex_ring(1)
             .unwrap();
         let polygons = ring.to_linked_polygons(false);

--- a/h3ron/src/to_geo.rs
+++ b/h3ron/src/to_geo.rs
@@ -70,7 +70,7 @@ impl ToAlignedLinkedPolygons for Vec<Index> {
     ) -> Vec<Polygon<f64>> {
         let mut h3indexes_grouped = HashMap::new();
         for i in self.iter() {
-            let parent = i.get_parent(align_to_h3_resolution);
+            let parent = i.get_parent_unchecked(align_to_h3_resolution);
             h3indexes_grouped
                 .entry(parent)
                 .or_insert_with(Vec::new)

--- a/h3ron/src/to_h3.rs
+++ b/h3ron/src/to_h3.rs
@@ -19,7 +19,7 @@ impl ToH3Indexes for Polygon<f64> {
     fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = polyfill(&self, h3_resolution);
-        Ok(indexes.drain(..).map(|i| Index::new(i)).collect())
+        Ok(indexes.drain(..).map(Index::new).collect())
     }
 }
 
@@ -37,7 +37,7 @@ impl ToH3Indexes for MultiPolygon<f64> {
 impl ToH3Indexes for Point<f64> {
     fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![Index::from_coordinate(&self.0, h3_resolution)])
+        Ok(vec![Index::from_coordinate(&self.0, h3_resolution)?])
     }
 }
 
@@ -45,7 +45,7 @@ impl ToH3Indexes for MultiPoint<f64> {
     fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
         let mut outvec = vec![];
         for pt in self.0.iter() {
-            outvec.push(Index::from_coordinate(&pt.0, h3_resolution));
+            outvec.push(Index::from_coordinate(&pt.0, h3_resolution)?);
         }
         Ok(outvec)
     }
@@ -54,7 +54,7 @@ impl ToH3Indexes for MultiPoint<f64> {
 impl ToH3Indexes for Coordinate<f64> {
     fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![Index::from_coordinate(&self, h3_resolution)])
+        Ok(vec![Index::from_coordinate(&self, h3_resolution)?])
     }
 }
 
@@ -62,7 +62,7 @@ impl ToH3Indexes for LineString<f64> {
     fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = line(&self, h3_resolution)?;
-        Ok(indexes.drain(..).map(|i| Index::new(i)).collect())
+        Ok(indexes.drain(..).map(Index::new).collect())
     }
 }
 


### PR DESCRIPTION
The current `get_parent` method never fails so I added a *checked* and  *unchecked* version.

I fixed a few `clippy` warnings.