### PR TITLE
Edge and Hexagon indexes

### DIFF
--- a/h3ron-ndarray/examples/h3ify_r_tiff.rs
+++ b/h3ron-ndarray/examples/h3ify_r_tiff.rs
@@ -3,7 +3,7 @@ use gdal::{
     Dataset, Driver,
 };
 
-use h3ron::{HexagonIndex, ToPolygon};
+use h3ron::{HexagonIndex, Index, ToPolygon};
 use h3ron_ndarray::{AxisOrder, H3Converter, ResolutionSearchMode::SmallerThanPixel, Transform};
 use std::convert::TryFrom;
 

--- a/h3ron-ndarray/examples/h3ify_r_tiff.rs
+++ b/h3ron-ndarray/examples/h3ify_r_tiff.rs
@@ -3,7 +3,7 @@ use gdal::{
     Dataset, Driver,
 };
 
-use h3ron::{Index, ToPolygon};
+use h3ron::{HexagonIndex, ToPolygon};
 use h3ron_ndarray::{AxisOrder, H3Converter, ResolutionSearchMode::SmallerThanPixel, Transform};
 use std::convert::TryFrom;
 
@@ -47,7 +47,7 @@ fn main() {
 
     results.iter().for_each(|(_value, index_stack)| {
         for h3index in index_stack.iter_compacted_indexes() {
-            let index = Index::try_from(h3index).unwrap();
+            let index = HexagonIndex::try_from(h3index).unwrap();
             let mut ft = Feature::new(&defn).unwrap();
             ft.set_geometry(index.to_polygon().to_gdal().unwrap())
                 .unwrap();

--- a/h3ron-ndarray/src/array.rs
+++ b/h3ron-ndarray/src/array.rs
@@ -6,7 +6,7 @@ use geo_types::{Coordinate, Rect};
 use log::debug;
 use ndarray::{parallel::prelude::*, ArrayView2, Axis};
 
-use h3ron::{collections::H3CompactedVec, polyfill, Index, ToCoordinate};
+use h3ron::{collections::H3CompactedVec, polyfill, HexagonIndex, Index, ToCoordinate};
 
 use crate::resolution::{nearest_h3_resolution, ResolutionSearchMode};
 use crate::{error::Error, transform::Transform};
@@ -289,7 +289,8 @@ where
                 for h3index in h3indexes {
                     // find the array element for the coordinate of the h3ron index
                     let arr_coord = {
-                        let transformed = &inverse_transform * &Index::new(h3index).to_coordinate();
+                        let transformed =
+                            &inverse_transform * &HexagonIndex::new(h3index).to_coordinate();
 
                         match self.axis_order {
                             AxisOrder::XY => [

--- a/h3ron-ndarray/src/resolution.rs
+++ b/h3ron-ndarray/src/resolution.rs
@@ -7,7 +7,7 @@ use crate::{
     AxisOrder,
 };
 
-use h3ron::{Index, ToPolygon, H3_MAX_RESOLUTION, H3_MIN_RESOLUTION};
+use h3ron::{HexagonIndex, ToPolygon, H3_MAX_RESOLUTION, H3_MIN_RESOLUTION};
 
 pub enum ResolutionSearchMode {
     /// chose the h3 resolution where the difference in the area of a pixel and the h3index is
@@ -50,7 +50,7 @@ pub fn nearest_h3_resolution(
         // calculate the area of the center index to avoid using the approximate values
         // of the h3ron hexArea functions
         let area_h3_index = area_linearring(
-            Index::from_coordinate_unchecked(&center_of_array, h3_res)
+            HexagonIndex::from_coordinate_unchecked(&center_of_array, h3_res)
                 .to_polygon()
                 .exterior(),
         );

--- a/h3ron/src/algorithm.rs
+++ b/h3ron/src/algorithm.rs
@@ -79,11 +79,11 @@ mod tests {
     use geo_types::Coordinate;
 
     use crate::algorithm::smoothen_h3_linked_polygon;
-    use crate::{Index, ToLinkedPolygons};
+    use crate::{HexagonIndex, ToLinkedPolygons};
 
     #[test]
     fn smooth_donut_linked_polygon() {
-        let ring = Index::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+        let ring = HexagonIndex::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
             .unwrap()
             .hex_ring(4)
             .unwrap();

--- a/h3ron/src/edge_index.rs
+++ b/h3ron/src/edge_index.rs
@@ -1,0 +1,57 @@
+use crate::index::Index;
+use crate::{Error, FromH3Index};
+use h3ron_h3_sys::H3Index;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::ffi::CString;
+use std::str::FromStr;
+
+/// a single H3 index
+#[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
+pub struct EdgeIndex(H3Index);
+
+/// convert to index including validation
+impl TryFrom<u64> for EdgeIndex {
+    type Error = Error;
+
+    fn try_from(h3index: H3Index) -> Result<Self, Self::Error> {
+        let index = Self::new(h3index);
+        index.validate()?;
+        Ok(index)
+    }
+}
+
+impl EdgeIndex {}
+
+impl FromH3Index for EdgeIndex {
+    fn from_h3index(h3index: H3Index) -> Self {
+        EdgeIndex::new(h3index)
+    }
+}
+
+impl Index for EdgeIndex {
+    fn h3index(&self) -> H3Index {
+        self.0
+    }
+
+    fn new(h3index: H3Index) -> Self {
+        Self(h3index)
+    }
+}
+
+impl ToString for EdgeIndex {
+    fn to_string(&self) -> String {
+        format!("{:x}", self.0)
+    }
+}
+
+impl FromStr for EdgeIndex {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let h3index: H3Index = CString::new(s)
+            .map(|cs| unsafe { h3ron_h3_sys::stringToH3(cs.as_ptr()) })
+            .map_err(|_| Error::InvalidInput)?;
+        Self::try_from(h3index)
+    }
+}

--- a/h3ron/src/edge_index.rs
+++ b/h3ron/src/edge_index.rs
@@ -1,12 +1,13 @@
 use crate::index::Index;
-use crate::{Error, FromH3Index};
+use crate::{Error, FromH3Index, HexagonIndex};
 use h3ron_h3_sys::H3Index;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::ffi::CString;
+use std::os::raw::c_int;
 use std::str::FromStr;
 
-/// a single H3 index
+/// H3 Index representing an Unidirectional H3 edge
 #[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
 pub struct EdgeIndex(H3Index);
 
@@ -21,7 +22,79 @@ impl TryFrom<u64> for EdgeIndex {
     }
 }
 
-impl EdgeIndex {}
+impl EdgeIndex {
+    pub fn is_edge_valid(&self) -> bool {
+        unsafe { h3ron_h3_sys::h3UnidirectionalEdgeIsValid(self.h3index()) != 0 }
+    }
+
+    /// Gets the average length of an edge in kilometers at `resolution`
+    pub fn edge_length_km(resolution: u8) -> f64 {
+        unsafe { h3ron_h3_sys::edgeLengthKm(resolution as c_int) }
+    }
+
+    /// Gets the average length of an edge in meters at `resolution`
+    pub fn edge_length_m(resolution: u8) -> f64 {
+        unsafe { h3ron_h3_sys::edgeLengthM(resolution as c_int) }
+    }
+
+    /// Retrieves the exact length of `self` in kilometers
+    pub fn exact_length_km(&self) -> f64 {
+        unsafe { h3ron_h3_sys::exactEdgeLengthKm(self.h3index()) }
+    }
+
+    /// Retrieves the exact length of `self` in meters
+    pub fn exact_length_m(&self) -> f64 {
+        unsafe { h3ron_h3_sys::exactEdgeLengthM(self.h3index()) }
+    }
+
+    /// Retrieves the exact length of `self` in radians
+    pub fn exact_length_rads(&self) -> f64 {
+        unsafe { h3ron_h3_sys::exactEdgeLengthRads(self.h3index()) }
+    }
+
+    /// Retrieves the destination hexagon H3 Index of `self`
+    ///
+    /// # Returns
+    /// The built index may be invalid.
+    /// Use the `destination_index` method for validity check.
+    pub fn destination_index_unchecked(&self) -> HexagonIndex {
+        let index =
+            unsafe { h3ron_h3_sys::getDestinationH3IndexFromUnidirectionalEdge(self.h3index()) };
+        HexagonIndex::new(index)
+    }
+
+    /// Retrieves the destination hexagon H3 Index of `self`
+    ///
+    /// # Returns
+    /// If the built index is invalid, returns an Error.
+    /// Use the `destination_index_unchecked` to avoid error.
+    pub fn destination_index(&self) -> Result<HexagonIndex, Error> {
+        let res = self.destination_index_unchecked();
+        res.validate()?;
+        Ok(res)
+    }
+
+    /// Retrieves the origin hexagon H3 Index of `self`
+    ///
+    /// # Returns
+    /// The built index may be invalid.
+    /// Use the `origin_index` method for validity check.
+    pub fn origin_index_unchecked(&self) -> HexagonIndex {
+        let index = unsafe { h3ron_h3_sys::getOriginH3IndexFromUnidirectionalEdge(self.h3index()) };
+        HexagonIndex::new(index)
+    }
+
+    /// Retrieves the origin hexagon H3 Index of `self`
+    ///
+    /// # Returns
+    /// If the built index is invalid, returns an Error.
+    /// Use the `origin_index_unchecked` to avoid error.
+    pub fn origin_index(&self) -> Result<HexagonIndex, Error> {
+        let res = self.origin_index_unchecked();
+        res.validate()?;
+        Ok(res)
+    }
+}
 
 impl FromH3Index for EdgeIndex {
     fn from_h3index(h3index: H3Index) -> Self {
@@ -36,6 +109,14 @@ impl Index for EdgeIndex {
 
     fn new(h3index: H3Index) -> Self {
         Self(h3index)
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        if !self.is_edge_valid() {
+            Err(Error::InvalidH3Edge(self.h3index()))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -53,5 +134,31 @@ impl FromStr for EdgeIndex {
             .map(|cs| unsafe { h3ron_h3_sys::stringToH3(cs.as_ptr()) })
             .map_err(|_| Error::InvalidInput)?;
         Self::try_from(h3index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[should_panic(expected = "InvalidH3Edge")]
+    #[test]
+    fn checks_both_validity() {
+        let edge = EdgeIndex::new(0x149283080ddbffff);
+        assert!(edge.validate().is_ok());
+        let edge = EdgeIndex::new(0x89283080ddbffff_u64);
+        edge.validate().unwrap();
+    }
+
+    #[test]
+    fn can_find_parent() {
+        let edge = EdgeIndex::new(0x149283080ddbffff);
+        assert_eq!(edge.resolution(), 9);
+        let parent_8 = edge.get_parent(8).unwrap();
+        assert_eq!(parent_8.resolution(), 8);
+        assert!(edge.is_child_of(&parent_8));
+        let parent_1 = edge.get_parent(1).unwrap();
+        assert_eq!(parent_1.resolution(), 1);
+        assert!(edge.is_child_of(&parent_1));
     }
 }

--- a/h3ron/src/error.rs
+++ b/h3ron/src/error.rs
@@ -11,23 +11,23 @@ pub enum Error {
     InvalidH3Edge(H3Index),
     PentagonalDistortion,
     LineNotComputable,
-    MixedResolutions,
+    MixedResolutions(u8, u8),
     UnsupportedOperation,
-    InvalidH3Resolution,
+    InvalidH3Resolution(u8),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidInput => write!(f, "invalid input"),
-            Self::InvalidH3Hexagon(i) => write!(f, "invalid h3ron index {:x}", i),
+            Self::InvalidH3Hexagon(i) => write!(f, "invalid h3ron hexagon index {:x}", i),
             Self::InvalidH3Edge(i) => write!(f, "invalid h3ron edge index {:x}", i),
             Self::NoLocalIJCoordinates => write!(f, "no local IJ coordinates found"),
             Self::PentagonalDistortion => write!(f, "pentagonal distortion"),
             Self::LineNotComputable => write!(f, "line is not computable"),
-            Self::MixedResolutions => write!(f, "mixed h3 resolutions"),
+            Self::MixedResolutions(r1, r2) => write!(f, "mixed h3 resolutions: {} and {}", r1, r2),
             Self::UnsupportedOperation => write!(f, "unsupported operation"),
-            Self::InvalidH3Resolution => write!(f, "invalid h3 resolution"),
+            Self::InvalidH3Resolution(r) => write!(f, "invalid h3 resolution: {}", r),
         }
     }
 }
@@ -36,9 +36,10 @@ impl std::error::Error for Error {}
 
 /// ensure two indexes have the same resolution
 pub fn check_same_resolution(index0: H3Index, index1: H3Index) -> Result<(), Error> {
-    if HexagonIndex::try_from(index0)?.resolution() != HexagonIndex::try_from(index1)?.resolution()
-    {
-        Err(Error::MixedResolutions)
+    let res0 = HexagonIndex::try_from(index0)?.resolution();
+    let res1 = HexagonIndex::try_from(index1)?.resolution();
+    if res0 != res1 {
+        Err(Error::MixedResolutions(res0, res1))
     } else {
         Ok(())
     }
@@ -47,7 +48,7 @@ pub fn check_same_resolution(index0: H3Index, index1: H3Index) -> Result<(), Err
 /// ensure the given resolution is valid
 pub fn check_valid_h3_resolution(h3_res: u8) -> Result<(), Error> {
     if h3_res > H3_MAX_RESOLUTION {
-        Err(Error::InvalidH3Resolution)
+        Err(Error::InvalidH3Resolution(h3_res))
     } else {
         Ok(())
     }

--- a/h3ron/src/error.rs
+++ b/h3ron/src/error.rs
@@ -7,7 +7,8 @@ use std::fmt;
 pub enum Error {
     NoLocalIJCoordinates,
     InvalidInput,
-    InvalidH3Index,
+    InvalidH3Hexagon(H3Index),
+    InvalidH3Edge(H3Index),
     PentagonalDistortion,
     LineNotComputable,
     MixedResolutions,
@@ -19,7 +20,8 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidInput => write!(f, "invalid input"),
-            Self::InvalidH3Index => write!(f, "invalid h3ron index"),
+            Self::InvalidH3Hexagon(i) => write!(f, "invalid h3ron index {:x}", i),
+            Self::InvalidH3Edge(i) => write!(f, "invalid h3ron edge index {:x}", i),
             Self::NoLocalIJCoordinates => write!(f, "no local IJ coordinates found"),
             Self::PentagonalDistortion => write!(f, "pentagonal distortion"),
             Self::LineNotComputable => write!(f, "line is not computable"),

--- a/h3ron/src/error.rs
+++ b/h3ron/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{Index, H3_MAX_RESOLUTION};
+use crate::{HexagonIndex, Index, H3_MAX_RESOLUTION};
 use h3ron_h3_sys::H3Index;
 use std::convert::TryFrom;
 use std::fmt;
@@ -34,7 +34,8 @@ impl std::error::Error for Error {}
 
 /// ensure two indexes have the same resolution
 pub fn check_same_resolution(index0: H3Index, index1: H3Index) -> Result<(), Error> {
-    if Index::try_from(index0)?.resolution() != Index::try_from(index1)?.resolution() {
+    if HexagonIndex::try_from(index0)?.resolution() != HexagonIndex::try_from(index1)?.resolution()
+    {
         Err(Error::MixedResolutions)
     } else {
         Ok(())

--- a/h3ron/src/experimental.rs
+++ b/h3ron/src/experimental.rs
@@ -3,8 +3,8 @@ use std::result::Result;
 use h3ron_h3_sys::H3Index;
 
 use crate::error::Error;
-use crate::index::Index;
-use crate::HasH3Index;
+use crate::hexagon_index::HexagonIndex;
+use crate::Index;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CoordIJ {
@@ -18,7 +18,7 @@ impl Default for CoordIJ {
     }
 }
 
-pub fn h3_to_local_ij(origin_index: &Index, index: &Index) -> Result<CoordIJ, Error> {
+pub fn h3_to_local_ij(origin_index: &HexagonIndex, index: &HexagonIndex) -> Result<CoordIJ, Error> {
     unsafe {
         let mut cij = h3ron_h3_sys::CoordIJ { i: 0, j: 0 };
         if h3ron_h3_sys::experimentalH3ToLocalIj(origin_index.h3index(), index.h3index(), &mut cij)
@@ -31,7 +31,10 @@ pub fn h3_to_local_ij(origin_index: &Index, index: &Index) -> Result<CoordIJ, Er
     }
 }
 
-pub fn local_ij_to_h3(origin_index: &Index, coordij: &CoordIJ) -> Result<Index, Error> {
+pub fn local_ij_to_h3(
+    origin_index: &HexagonIndex,
+    coordij: &CoordIJ,
+) -> Result<HexagonIndex, Error> {
     unsafe {
         let cij = h3ron_h3_sys::CoordIJ {
             i: coordij.i,
@@ -41,7 +44,7 @@ pub fn local_ij_to_h3(origin_index: &Index, coordij: &CoordIJ) -> Result<Index, 
         if h3ron_h3_sys::experimentalLocalIjToH3(origin_index.h3index(), &cij, &mut h3_index_out)
             == 0
         {
-            Ok(Index::new(h3_index_out))
+            Ok(HexagonIndex::new(h3_index_out))
         } else {
             Err(Error::NoLocalIJCoordinates)
         }
@@ -51,12 +54,12 @@ pub fn local_ij_to_h3(origin_index: &Index, coordij: &CoordIJ) -> Result<Index, 
 #[cfg(test)]
 mod tests {
     use crate::experimental::{h3_to_local_ij, local_ij_to_h3};
-    use crate::index::Index;
+    use crate::hexagon_index::HexagonIndex;
     use std::convert::TryFrom;
 
     #[test]
     fn test_local_ij() {
-        let origin_index = Index::try_from(0x89283080ddbffff_u64).unwrap();
+        let origin_index = HexagonIndex::try_from(0x89283080ddbffff_u64).unwrap();
         let ring = origin_index.k_ring(1);
         assert_ne!(ring.len(), 0);
         let other_index = ring.iter().find(|i| **i != origin_index).unwrap().clone();

--- a/h3ron/src/hexagon_index.rs
+++ b/h3ron/src/hexagon_index.rs
@@ -1,0 +1,426 @@
+use std::convert::TryFrom;
+use std::ffi::CString;
+use std::mem::MaybeUninit;
+use std::os::raw::c_int;
+use std::str::FromStr;
+
+use geo_types::{Coordinate, LineString, Point, Polygon};
+use serde::{Deserialize, Serialize};
+
+use h3ron_h3_sys::{GeoCoord, H3Index};
+
+use crate::error::Error;
+use crate::index::Index;
+use crate::util::{coordinate_to_geocoord, drain_h3indexes_to_indexes, point_to_geocoord};
+use crate::{max_k_ring_size, AreaUnits, FromH3Index, ToCoordinate, ToPolygon};
+
+/// a single H3 index
+#[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
+pub struct HexagonIndex(H3Index);
+
+/// convert to index including validation
+impl TryFrom<u64> for HexagonIndex {
+    type Error = Error;
+
+    fn try_from(h3index: H3Index) -> Result<Self, Self::Error> {
+        let index = Self::new(h3index);
+        index.validate()?;
+        Ok(index)
+    }
+}
+
+impl FromH3Index for HexagonIndex {
+    fn from_h3index(h3index: H3Index) -> Self {
+        Self::new(h3index)
+    }
+}
+
+impl Index for HexagonIndex {
+    fn h3index(&self) -> H3Index {
+        self.0
+    }
+
+    fn new(h3index: H3Index) -> Self {
+        Self(h3index)
+    }
+}
+
+impl HexagonIndex {
+    /// Build a new `Index` from a `Point`.
+    ///
+    /// # Returns
+    /// The built index may be invalid.
+    /// Use the `from_point` method for validity check.
+    pub fn from_point_unchecked(pt: &Point<f64>, h3_resolution: u8) -> Self {
+        let h3index = unsafe {
+            let gc = point_to_geocoord(pt);
+            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
+        };
+        Self::new(h3index)
+    }
+
+    /// Build a new `Index` from a `Point`.
+    ///
+    /// # Returns
+    /// If the built index is invalid, returns an Error.
+    /// Use the `from_point_unchecked` to avoid error.
+    pub fn from_point(pt: &Point<f64>, h3_resolution: u8) -> Result<Self, Error> {
+        let res = Self::from_point_unchecked(pt, h3_resolution);
+        res.validate()?;
+        Ok(res)
+    }
+
+    /// Build a new `Index` from coordinates.
+    ///
+    /// # Returns
+    /// The built index may be invalid.
+    /// Use the `from_coordinate` method for validity check.
+    pub fn from_coordinate_unchecked(c: &Coordinate<f64>, h3_resolution: u8) -> Self {
+        let h3index = unsafe {
+            let gc = coordinate_to_geocoord(c);
+            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
+        };
+        Self::new(h3index)
+    }
+
+    /// Build a new `Index` from coordinates.
+    ///
+    /// # Returns
+    /// If the built index is invalid, returns an Error.
+    /// Use the `from_coordinate_unchecked` to avoid error.
+    pub fn from_coordinate(c: &Coordinate<f64>, h3_resolution: u8) -> Result<Self, Error> {
+        let res = Self::from_coordinate_unchecked(c, h3_resolution);
+        res.validate()?;
+        Ok(res)
+    }
+
+    /// Checks if the current index and `other` are neighbors.
+    pub fn is_neighbor_to(&self, other: &Self) -> bool {
+        let res: i32 = unsafe { h3ron_h3_sys::h3IndexesAreNeighbors(self.0, other.0) };
+        res == 1
+    }
+
+    pub fn k_ring(&self, k: u32) -> Vec<HexagonIndex> {
+        let max_size = unsafe { h3ron_h3_sys::maxKringSize(k as i32) as usize };
+        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
+
+        unsafe {
+            h3ron_h3_sys::kRing(self.0, k as c_int, h3_indexes_out.as_mut_ptr());
+        }
+        remove_zero_indexes_from_vec!(h3_indexes_out);
+        drain_h3indexes_to_indexes(h3_indexes_out)
+    }
+
+    pub fn hex_ring(&self, k: u32) -> Result<Vec<HexagonIndex>, Error> {
+        // calculation of max_size taken from
+        // https://github.com/uber/h3-py/blob/dd08189b378429291c342d0af3d3cc1e38a659d5/src/h3/_cy/cells.pyx#L111
+        let max_size = if k > 0 { 6 * k as usize } else { 1 };
+        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
+
+        let res = unsafe {
+            h3ron_h3_sys::hexRing(self.0, k as c_int, h3_indexes_out.as_mut_ptr()) as c_int
+        };
+        if res == 0 {
+            Ok(drain_h3indexes_to_indexes(h3_indexes_out))
+        } else {
+            Err(Error::PentagonalDistortion)
+        }
+    }
+
+    /// Retrieves indexes around `self` through K Rings.
+    ///
+    /// # Arguments
+    ///
+    /// * `k_min` - the minimum k ring distance
+    /// * `k_max` - the maximum k ring distance
+    ///
+    /// # Returns
+    ///
+    /// A `Vec` of `(u32, Index)` tuple is returned. The `u32` value is the K Ring distance
+    /// of the `Index` value.
+    pub fn k_ring_distances(&self, k_min: u32, k_max: u32) -> Vec<(u32, HexagonIndex)> {
+        let max_size = max_k_ring_size(k_max);
+        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
+        let mut distances_out: Vec<c_int> = vec![0; max_size];
+        unsafe {
+            h3ron_h3_sys::kRingDistances(
+                self.0,
+                k_max as c_int,
+                h3_indexes_out.as_mut_ptr(),
+                distances_out.as_mut_ptr(),
+            )
+        };
+        self.associate_index_distances(h3_indexes_out, distances_out, k_min)
+    }
+
+    pub fn hex_range_distances(
+        &self,
+        k_min: u32,
+        k_max: u32,
+    ) -> Result<Vec<(u32, HexagonIndex)>, Error> {
+        let max_size = unsafe { h3ron_h3_sys::maxKringSize(k_max as c_int) as usize };
+        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
+        let mut distances_out: Vec<c_int> = vec![0; max_size];
+        let res = unsafe {
+            h3ron_h3_sys::hexRangeDistances(
+                self.0,
+                k_max as c_int,
+                h3_indexes_out.as_mut_ptr(),
+                distances_out.as_mut_ptr(),
+            ) as c_int
+        };
+        if res == 0 {
+            Ok(self.associate_index_distances(h3_indexes_out, distances_out, k_min))
+        } else {
+            Err(Error::PentagonalDistortion) // may also be PentagonEncountered
+        }
+    }
+
+    /// Retrieves the number of K Rings between `self` and `other`.
+    ///
+    /// For distance in miles or kilometers use haversine algorithms.
+    pub fn distance_to(&self, other: &Self) -> i32 {
+        unsafe { h3ron_h3_sys::h3Distance(self.0, other.0) }
+    }
+
+    fn associate_index_distances(
+        &self,
+        mut h3_indexes_out: Vec<H3Index>,
+        distances_out: Vec<c_int>,
+        k_min: u32,
+    ) -> Vec<(u32, HexagonIndex)> {
+        h3_indexes_out
+            .drain(..)
+            .enumerate()
+            .filter(|(idx, h3index)| *h3index != 0 && distances_out[*idx] >= k_min as i32)
+            .map(|(idx, h3index)| (distances_out[idx] as u32, HexagonIndex::new(h3index)))
+            .collect()
+    }
+
+    /// exact area for a specific cell (hexagon or pentagon)
+    pub fn area(&self, area_units: AreaUnits) -> f64 {
+        match area_units {
+            AreaUnits::M2 => unsafe { h3ron_h3_sys::cellAreaM2(self.0) },
+            AreaUnits::Km2 => unsafe { h3ron_h3_sys::cellAreaKm2(self.0) },
+            AreaUnits::Radians2 => unsafe { h3ron_h3_sys::cellAreaRads2(self.0) },
+        }
+    }
+
+    /// determines if an H3 cell is a pentagon
+    pub fn is_pentagon(&self) -> bool {
+        unsafe { h3ron_h3_sys::h3IsPentagon(self.0) == 1 }
+    }
+
+    /// returns the base cell "number" (0 to 121) of the provided H3 cell
+    pub fn get_base_cell(&self) -> u8 {
+        unsafe { h3ron_h3_sys::h3GetBaseCell(self.0) as u8 }
+    }
+}
+
+impl ToString for HexagonIndex {
+    fn to_string(&self) -> String {
+        format!("{:x}", self.0)
+    }
+}
+
+impl FromStr for HexagonIndex {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let h3index: H3Index = CString::new(s)
+            .map(|cs| unsafe { h3ron_h3_sys::stringToH3(cs.as_ptr()) })
+            .map_err(|_| Error::InvalidInput)?;
+        HexagonIndex::try_from(h3index)
+    }
+}
+
+impl ToPolygon for HexagonIndex {
+    /// the polygon spanning the area of the index
+    fn to_polygon(&self) -> Polygon<f64> {
+        let gb = unsafe {
+            let mut mu = MaybeUninit::<h3ron_h3_sys::GeoBoundary>::uninit();
+            h3ron_h3_sys::h3ToGeoBoundary(self.0, mu.as_mut_ptr());
+            mu.assume_init()
+        };
+
+        let mut nodes = vec![];
+        for i in 0..gb.numVerts {
+            nodes.push((
+                unsafe { h3ron_h3_sys::radsToDegs(gb.verts[i as usize].lon) },
+                unsafe { h3ron_h3_sys::radsToDegs(gb.verts[i as usize].lat) },
+            ));
+        }
+        nodes.push(*nodes.first().unwrap());
+        Polygon::new(LineString::from(nodes), vec![])
+    }
+}
+
+impl ToCoordinate for HexagonIndex {
+    /// the centroid coordinate of the h3 index
+    fn to_coordinate(&self) -> Coordinate<f64> {
+        unsafe {
+            let mut gc = GeoCoord { lat: 0.0, lon: 0.0 };
+            h3ron_h3_sys::h3ToGeo(self.0, &mut gc);
+
+            Coordinate {
+                x: h3ron_h3_sys::radsToDegs(gc.lon),
+                y: h3ron_h3_sys::radsToDegs(gc.lat),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::convert::{TryFrom, TryInto};
+    use std::str::FromStr;
+
+    use bincode::{deserialize, serialize};
+
+    use h3ron_h3_sys::H3Index;
+
+    use crate::hexagon_index::HexagonIndex;
+    use crate::Index;
+
+    #[test]
+    fn test_h3_to_string() {
+        let h3index = 0x89283080ddbffff_u64;
+        assert_eq!(
+            HexagonIndex::try_from(h3index).unwrap().to_string(),
+            "89283080ddbffff".to_string()
+        );
+    }
+
+    #[test]
+    fn test_string_to_h3() {
+        let index = HexagonIndex::from_str("89283080ddbffff").expect("parsing failed");
+        assert_eq!(
+            HexagonIndex::try_from(0x89283080ddbffff_u64).unwrap(),
+            index
+        );
+    }
+
+    #[test]
+    fn test_is_valid() {
+        assert_eq!(
+            HexagonIndex::try_from(0x89283080ddbffff_u64)
+                .unwrap()
+                .is_valid(),
+            true
+        );
+        assert_eq!(HexagonIndex::new(0_u64).is_valid(), false);
+        assert!(HexagonIndex::try_from(0_u64).is_err());
+    }
+
+    #[test]
+    fn test_hex_ring_1() {
+        let idx = HexagonIndex::try_from(0x89283080ddbffff_u64).unwrap();
+        let ring = idx.hex_ring(1).unwrap();
+        assert_eq!(ring.len(), 6);
+        assert!(ring.iter().all(|index| index.is_valid()));
+    }
+
+    #[test]
+    fn test_hex_ring_0() {
+        let idx = HexagonIndex::new(0x89283080ddbffff_u64);
+        let ring = idx.hex_ring(0).unwrap();
+        assert_eq!(ring.len(), 1);
+        assert!(ring.iter().all(|index| index.is_valid()));
+    }
+
+    #[test]
+    fn test_k_ring_distances() {
+        let idx = HexagonIndex::new(0x89283080ddbffff_u64);
+        let k_min = 2;
+        let k_max = 2;
+        let indexes = idx.k_ring_distances(k_min, k_max);
+        assert!(indexes.len() > 10);
+        for (k, index) in indexes.iter() {
+            assert!(index.is_valid());
+            assert!(*k >= k_min);
+            assert!(*k <= k_max);
+        }
+    }
+
+    #[test]
+    fn test_hex_range_distances() {
+        let idx = HexagonIndex::new(0x89283080ddbffff_u64);
+        let k_min = 2;
+        let k_max = 2;
+        let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
+        assert!(indexes.len() > 10);
+        for (k, index) in indexes.iter() {
+            assert!(index.is_valid());
+            assert!(*k >= k_min);
+            assert!(*k <= k_max);
+        }
+    }
+
+    #[test]
+    fn test_hex_range_distances_2() {
+        let idx = HexagonIndex::new(0x89283080ddbffff_u64);
+        let k_min = 0;
+        let k_max = 10;
+        let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
+
+        let mut indexes_resolutions: HashMap<H3Index, Vec<u32>> = HashMap::new();
+        for (dist, idx) in indexes.iter() {
+            indexes_resolutions
+                .entry(idx.h3index())
+                .and_modify(|v| v.push(*dist))
+                .or_insert_with(|| vec![*dist]);
+        }
+
+        println!("{:?}", indexes_resolutions);
+        assert!(indexes.len() > 10);
+        for (k, index) in indexes.iter() {
+            assert!(index.is_valid());
+            assert!(*k >= k_min);
+            assert!(*k <= k_max);
+        }
+    }
+
+    #[test]
+    fn serde_index_roundtrip() {
+        let idx = HexagonIndex::new(0x89283080ddbffff_u64);
+        let serialized_data = serialize(&idx).unwrap();
+        let idx_2: HexagonIndex = deserialize(&serialized_data).unwrap();
+        assert_eq!(idx, idx_2);
+        assert_eq!(idx.h3index(), idx_2.h3index());
+    }
+
+    /// this test is not really a hard requirement, but it is nice to know
+    /// Index is handled just like an u64
+    #[test]
+    fn serde_index_from_h3index() {
+        let idx: H3Index = 0x89283080ddbffff_u64;
+        let serialized_data = serialize(&idx).unwrap();
+        let idx_2: HexagonIndex = deserialize(&serialized_data).unwrap();
+        assert_eq!(idx, idx_2.h3index());
+    }
+
+    #[test]
+    fn test_is_neighbor() {
+        let idx: HexagonIndex = 0x89283080ddbffff_u64.try_into().unwrap();
+        let ring = idx.hex_ring(1).unwrap();
+        let neighbor = ring.first().unwrap();
+        assert!(idx.is_neighbor_to(neighbor));
+        let wrong_neighbor = 0x8a2a1072b59ffff_u64.try_into().unwrap();
+        assert!(!idx.is_neighbor_to(&wrong_neighbor));
+        // Self
+        assert!(!idx.is_neighbor_to(&idx));
+    }
+
+    #[test]
+    fn test_distance_to() {
+        let idx: HexagonIndex = 0x89283080ddbffff_u64.try_into().unwrap();
+        assert_eq!(idx.distance_to(&idx), 0);
+        let ring = idx.hex_ring(1).unwrap();
+        let neighbor = ring.first().unwrap();
+        assert_eq!(idx.distance_to(&neighbor), 1);
+        let ring = idx.hex_ring(3).unwrap();
+        let neighbor = ring.first().unwrap();
+        assert_eq!(idx.distance_to(&neighbor), 3);
+    }
+}

--- a/h3ron/src/hexagon_index.rs
+++ b/h3ron/src/hexagon_index.rs
@@ -472,17 +472,21 @@ mod tests {
         #[test]
         fn can_retrieve_edges() {
             let index: HexagonIndex = 0x89283080ddbffff_u64.try_into().unwrap();
+            assert_eq!(index.resolution(), 9);
             let edges = index.unidirectional_edges();
-            let indexes: Vec<String> = edges.into_iter().map(|e| e.to_string()).collect();
+            let indexes: Vec<(String, u8)> = edges
+                .into_iter()
+                .map(|e| (e.to_string(), e.resolution()))
+                .collect();
             assert_eq!(
                 indexes,
                 vec![
-                    "119283080ddbffff".to_string(),
-                    "129283080ddbffff".to_string(),
-                    "139283080ddbffff".to_string(),
-                    "149283080ddbffff".to_string(),
-                    "159283080ddbffff".to_string(),
-                    "169283080ddbffff".to_string()
+                    ("119283080ddbffff".to_string(), 9),
+                    ("129283080ddbffff".to_string(), 9),
+                    ("139283080ddbffff".to_string(), 9),
+                    ("149283080ddbffff".to_string(), 9),
+                    ("159283080ddbffff".to_string(), 9),
+                    ("169283080ddbffff".to_string(), 9)
                 ]
             );
         }

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -1,91 +1,19 @@
-use std::convert::TryFrom;
-use std::ffi::CString;
-use std::mem::MaybeUninit;
+use crate::util::drain_h3indexes_to_indexes;
+use crate::Error;
+use h3ron_h3_sys::H3Index;
 use std::os::raw::c_int;
-use std::str::FromStr;
 
-use geo_types::{Coordinate, LineString, Point, Polygon};
-use serde::{Deserialize, Serialize};
+pub trait Index: Sized + PartialEq {
+    /// Get the u64 H3 Index address
+    fn h3index(&self) -> H3Index;
 
-use h3ron_h3_sys::{GeoCoord, H3Index};
-
-use crate::error::Error;
-use crate::util::{coordinate_to_geocoord, drain_h3indexes_to_indexes, point_to_geocoord};
-use crate::{max_k_ring_size, AreaUnits, FromH3Index, HasH3Index, ToCoordinate, ToPolygon};
-
-/// a single H3 index
-#[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
-pub struct Index(H3Index);
-
-/*
-impl From<H3Index> for Index {
-    fn from(h3index: H3Index) -> Self {
-        Index(h3index)
-    }
-}
-
- */
-
-/// marker trait for indexes
-pub trait ToIndex {
-    fn to_index(&self) -> Index;
-}
-
-impl ToIndex for H3Index {
-    fn to_index(&self) -> Index {
-        Index::new(*self)
-    }
-}
-
-impl ToIndex for Index {
-    fn to_index(&self) -> Index {
-        *self
-    }
-}
-
-/// convert to index including validation
-impl TryFrom<u64> for Index {
-    type Error = Error;
-
-    fn try_from(h3index: H3Index) -> Result<Self, Self::Error> {
-        let index = Index::new(h3index);
-        index.validate()?;
-        Ok(index)
-    }
-}
-
-impl HasH3Index for Index {
-    fn h3index(&self) -> H3Index {
-        self.0
-    }
-}
-
-impl FromH3Index for Index {
-    fn from_h3index(h3index: H3Index) -> Self {
-        Index::new(h3index)
-    }
-}
-
-impl Index {
     /// create an index from the given u64.
     ///
-    /// No validation is performed - use the `TryInto` trait in
-    /// case that is desired.
-    pub fn new(h3index: H3Index) -> Self {
-        Self(h3index)
-    }
-
-    pub fn resolution(&self) -> u8 {
-        (unsafe { h3ron_h3_sys::h3GetResolution(self.0) }) as u8
-    }
+    /// No validation is performed.
+    fn new(h3index: H3Index) -> Self;
 
     /// Checks the validity of the index
-    pub fn is_valid(&self) -> bool {
-        unsafe { h3ron_h3_sys::h3IsValid(self.0) != 0 }
-    }
-
-    /// Checks the validity of the index
-    pub fn validate(&self) -> Result<(), Error> {
+    fn validate(&self) -> Result<(), Error> {
         if !self.is_valid() {
             Err(Error::InvalidH3Index)
         } else {
@@ -93,15 +21,28 @@ impl Index {
         }
     }
 
-    pub fn is_parent_of(&self, other: &Index) -> bool {
+    /// Gets the index resolution (0-15)
+    fn resolution(&self) -> u8 {
+        (unsafe { h3ron_h3_sys::h3GetResolution(self.h3index()) }) as u8
+    }
+
+    /// Checks the validity of the index
+    fn is_valid(&self) -> bool {
+        unsafe { h3ron_h3_sys::h3IsValid(self.h3index()) != 0 }
+    }
+
+    /// Checks if `self` is a parent of `other`
+    fn is_parent_of(&self, other: &Self) -> bool {
         *self == other.get_parent_unchecked(self.resolution())
     }
 
-    pub fn is_child_of(&self, other: &Index) -> bool {
+    /// Checks if `other` is a parent of `self`
+    fn is_child_of(&self, other: &Self) -> bool {
         other.is_parent_of(self)
     }
 
-    pub fn contains(&self, other: &Index) -> bool {
+    /// Checks if `self` is a parent of `other`
+    fn contains(&self, other: &Self) -> bool {
         self.is_parent_of(other)
     }
 
@@ -112,7 +53,7 @@ impl Index {
     /// This method may fail if the `parent_resolution` is higher than current `self` resolution.
     ///
     /// If you don't want it to fail use `get_parent_unchecked`
-    pub fn get_parent(&self, parent_resolution: u8) -> Result<Self, Error> {
+    fn get_parent(&self, parent_resolution: u8) -> Result<Self, Error> {
         let res = self.get_parent_unchecked(parent_resolution);
         res.validate()?;
         Ok(res)
@@ -126,390 +67,22 @@ impl Index {
     /// `self` resolution.
     ///
     /// Use `get_parent` for validity check.
-    pub fn get_parent_unchecked(&self, parent_resolution: u8) -> Self {
-        Index::new(unsafe { h3ron_h3_sys::h3ToParent(self.0, parent_resolution as c_int) })
+    fn get_parent_unchecked(&self, parent_resolution: u8) -> Self {
+        Self::new(unsafe { h3ron_h3_sys::h3ToParent(self.h3index(), parent_resolution as c_int) })
     }
 
-    pub fn get_children(&self, child_resolution: u8) -> Vec<Self> {
+    /// Retrieves all children of `self` at resolution `child_resolution`
+    fn get_children(&self, child_resolution: u8) -> Vec<Self> {
         let max_size =
-            unsafe { h3ron_h3_sys::maxH3ToChildrenSize(self.0, child_resolution as c_int) };
+            unsafe { h3ron_h3_sys::maxH3ToChildrenSize(self.h3index(), child_resolution as c_int) };
         let mut h3_indexes_out: Vec<h3ron_h3_sys::H3Index> = vec![0; max_size as usize];
         unsafe {
             h3ron_h3_sys::h3ToChildren(
-                self.0,
+                self.h3index(),
                 child_resolution as c_int,
                 h3_indexes_out.as_mut_ptr(),
             );
         }
         drain_h3indexes_to_indexes(h3_indexes_out)
-    }
-
-    /// Build a new `Index` from a `Point`.
-    ///
-    /// # Returns
-    /// The built index may be invalid.
-    /// Use the `from_point` method for validity check.
-    pub fn from_point_unchecked(pt: &Point<f64>, h3_resolution: u8) -> Self {
-        let h3index = unsafe {
-            let gc = point_to_geocoord(pt);
-            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
-        };
-        Index::new(h3index)
-    }
-
-    /// Build a new `Index` from a `Point`.
-    ///
-    /// # Returns
-    /// If the built index is invalid, returns an Error.
-    /// Use the `from_point_unchecked` to avoid error.
-    pub fn from_point(pt: &Point<f64>, h3_resolution: u8) -> Result<Self, Error> {
-        let res = Self::from_point_unchecked(pt, h3_resolution);
-        res.validate()?;
-        Ok(res)
-    }
-
-    /// Build a new `Index` from coordinates.
-    ///
-    /// # Returns
-    /// The built index may be invalid.
-    /// Use the `from_coordinate` method for validity check.
-    pub fn from_coordinate_unchecked(c: &Coordinate<f64>, h3_resolution: u8) -> Self {
-        let h3index = unsafe {
-            let gc = coordinate_to_geocoord(c);
-            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
-        };
-        Index::new(h3index)
-    }
-
-    /// Build a new `Index` from coordinates.
-    ///
-    /// # Returns
-    /// If the built index is invalid, returns an Error.
-    /// Use the `from_coordinate_unchecked` to avoid error.
-    pub fn from_coordinate(c: &Coordinate<f64>, h3_resolution: u8) -> Result<Self, Error> {
-        let res = Self::from_coordinate_unchecked(c, h3_resolution);
-        res.validate()?;
-        Ok(res)
-    }
-
-    /// Checks if the current index and `other` are neighbors.
-    pub fn is_neighbor_to(&self, other: &Self) -> bool {
-        let res: i32 = unsafe { h3ron_h3_sys::h3IndexesAreNeighbors(self.0, other.0) };
-        res == 1
-    }
-
-    pub fn k_ring(&self, k: u32) -> Vec<Index> {
-        let max_size = unsafe { h3ron_h3_sys::maxKringSize(k as i32) as usize };
-        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
-
-        unsafe {
-            h3ron_h3_sys::kRing(self.0, k as c_int, h3_indexes_out.as_mut_ptr());
-        }
-        remove_zero_indexes_from_vec!(h3_indexes_out);
-        drain_h3indexes_to_indexes(h3_indexes_out)
-    }
-
-    pub fn hex_ring(&self, k: u32) -> Result<Vec<Index>, Error> {
-        // calculation of max_size taken from
-        // https://github.com/uber/h3-py/blob/dd08189b378429291c342d0af3d3cc1e38a659d5/src/h3/_cy/cells.pyx#L111
-        let max_size = if k > 0 { 6 * k as usize } else { 1 };
-        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
-
-        let res = unsafe {
-            h3ron_h3_sys::hexRing(self.0, k as c_int, h3_indexes_out.as_mut_ptr()) as c_int
-        };
-        if res == 0 {
-            Ok(drain_h3indexes_to_indexes(h3_indexes_out))
-        } else {
-            Err(Error::PentagonalDistortion)
-        }
-    }
-
-    /// Retrieves indexes around `self` through K Rings.
-    ///
-    /// # Arguments
-    ///
-    /// * `k_min` - the minimum k ring distance
-    /// * `k_max` - the maximum k ring distance
-    ///
-    /// # Returns
-    ///
-    /// A `Vec` of `(u32, Index)` tuple is returned. The `u32` value is the K Ring distance
-    /// of the `Index` value.
-    pub fn k_ring_distances(&self, k_min: u32, k_max: u32) -> Vec<(u32, Index)> {
-        let max_size = max_k_ring_size(k_max);
-        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
-        let mut distances_out: Vec<c_int> = vec![0; max_size];
-        unsafe {
-            h3ron_h3_sys::kRingDistances(
-                self.0,
-                k_max as c_int,
-                h3_indexes_out.as_mut_ptr(),
-                distances_out.as_mut_ptr(),
-            )
-        };
-        self.associate_index_distances(h3_indexes_out, distances_out, k_min)
-    }
-
-    pub fn hex_range_distances(&self, k_min: u32, k_max: u32) -> Result<Vec<(u32, Index)>, Error> {
-        let max_size = unsafe { h3ron_h3_sys::maxKringSize(k_max as c_int) as usize };
-        let mut h3_indexes_out: Vec<H3Index> = vec![0; max_size];
-        let mut distances_out: Vec<c_int> = vec![0; max_size];
-        let res = unsafe {
-            h3ron_h3_sys::hexRangeDistances(
-                self.0,
-                k_max as c_int,
-                h3_indexes_out.as_mut_ptr(),
-                distances_out.as_mut_ptr(),
-            ) as c_int
-        };
-        if res == 0 {
-            Ok(self.associate_index_distances(h3_indexes_out, distances_out, k_min))
-        } else {
-            Err(Error::PentagonalDistortion) // may also be PentagonEncountered
-        }
-    }
-
-    /// Retrieves the number of K Rings between `self` and `other`.
-    ///
-    /// For distance in miles or kilometers use haversine algorithms.
-    pub fn distance_to(&self, other: &Self) -> i32 {
-        unsafe { h3ron_h3_sys::h3Distance(self.0, other.0) }
-    }
-
-    fn associate_index_distances(
-        &self,
-        mut h3_indexes_out: Vec<H3Index>,
-        distances_out: Vec<c_int>,
-        k_min: u32,
-    ) -> Vec<(u32, Index)> {
-        h3_indexes_out
-            .drain(..)
-            .enumerate()
-            .filter(|(idx, h3index)| *h3index != 0 && distances_out[*idx] >= k_min as i32)
-            .map(|(idx, h3index)| (distances_out[idx] as u32, Index::new(h3index)))
-            .collect()
-    }
-
-    /// exact area for a specific cell (hexagon or pentagon)
-    pub fn area(&self, area_units: AreaUnits) -> f64 {
-        match area_units {
-            AreaUnits::M2 => unsafe { h3ron_h3_sys::cellAreaM2(self.0) },
-            AreaUnits::Km2 => unsafe { h3ron_h3_sys::cellAreaKm2(self.0) },
-            AreaUnits::Radians2 => unsafe { h3ron_h3_sys::cellAreaRads2(self.0) },
-        }
-    }
-
-    /// determines if an H3 cell is a pentagon
-    pub fn is_pentagon(&self) -> bool {
-        unsafe { h3ron_h3_sys::h3IsPentagon(self.0) == 1 }
-    }
-
-    /// returns the base cell "number" (0 to 121) of the provided H3 cell
-    pub fn get_base_cell(&self) -> u8 {
-        unsafe { h3ron_h3_sys::h3GetBaseCell(self.0) as u8 }
-    }
-}
-
-impl ToString for Index {
-    fn to_string(&self) -> String {
-        format!("{:x}", self.0)
-    }
-}
-
-impl FromStr for Index {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let h3index: H3Index = CString::new(s)
-            .map(|cs| unsafe { h3ron_h3_sys::stringToH3(cs.as_ptr()) })
-            .map_err(|_| Error::InvalidInput)?;
-        Index::try_from(h3index)
-    }
-}
-
-impl ToPolygon for Index {
-    /// the polygon spanning the area of the index
-    fn to_polygon(&self) -> Polygon<f64> {
-        let gb = unsafe {
-            let mut mu = MaybeUninit::<h3ron_h3_sys::GeoBoundary>::uninit();
-            h3ron_h3_sys::h3ToGeoBoundary(self.0, mu.as_mut_ptr());
-            mu.assume_init()
-        };
-
-        let mut nodes = vec![];
-        for i in 0..gb.numVerts {
-            nodes.push((
-                unsafe { h3ron_h3_sys::radsToDegs(gb.verts[i as usize].lon) },
-                unsafe { h3ron_h3_sys::radsToDegs(gb.verts[i as usize].lat) },
-            ));
-        }
-        nodes.push(*nodes.first().unwrap());
-        Polygon::new(LineString::from(nodes), vec![])
-    }
-}
-
-impl ToCoordinate for Index {
-    /// the centroid coordinate of the h3 index
-    fn to_coordinate(&self) -> Coordinate<f64> {
-        unsafe {
-            let mut gc = GeoCoord { lat: 0.0, lon: 0.0 };
-            h3ron_h3_sys::h3ToGeo(self.0, &mut gc);
-
-            Coordinate {
-                x: h3ron_h3_sys::radsToDegs(gc.lon),
-                y: h3ron_h3_sys::radsToDegs(gc.lat),
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::convert::{TryFrom, TryInto};
-    use std::str::FromStr;
-
-    use bincode::{deserialize, serialize};
-
-    use h3ron_h3_sys::H3Index;
-
-    use crate::index::Index;
-    use crate::HasH3Index;
-
-    #[test]
-    fn test_h3_to_string() {
-        let h3index = 0x89283080ddbffff_u64;
-        assert_eq!(
-            Index::try_from(h3index).unwrap().to_string(),
-            "89283080ddbffff".to_string()
-        );
-    }
-
-    #[test]
-    fn test_string_to_h3() {
-        let index = Index::from_str("89283080ddbffff").expect("parsing failed");
-        assert_eq!(Index::try_from(0x89283080ddbffff_u64).unwrap(), index);
-    }
-
-    #[test]
-    fn test_is_valid() {
-        assert_eq!(
-            Index::try_from(0x89283080ddbffff_u64).unwrap().is_valid(),
-            true
-        );
-        assert_eq!(Index::new(0_u64).is_valid(), false);
-        assert!(Index::try_from(0_u64).is_err());
-    }
-
-    #[test]
-    fn test_hex_ring_1() {
-        let idx = Index::try_from(0x89283080ddbffff_u64).unwrap();
-        let ring = idx.hex_ring(1).unwrap();
-        assert_eq!(ring.len(), 6);
-        assert!(ring.iter().all(|index| index.is_valid()));
-    }
-
-    #[test]
-    fn test_hex_ring_0() {
-        let idx = Index::new(0x89283080ddbffff_u64);
-        let ring = idx.hex_ring(0).unwrap();
-        assert_eq!(ring.len(), 1);
-        assert!(ring.iter().all(|index| index.is_valid()));
-    }
-
-    #[test]
-    fn test_k_ring_distances() {
-        let idx = Index::new(0x89283080ddbffff_u64);
-        let k_min = 2;
-        let k_max = 2;
-        let indexes = idx.k_ring_distances(k_min, k_max);
-        assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
-            assert!(index.is_valid());
-            assert!(*k >= k_min);
-            assert!(*k <= k_max);
-        }
-    }
-
-    #[test]
-    fn test_hex_range_distances() {
-        let idx = Index::new(0x89283080ddbffff_u64);
-        let k_min = 2;
-        let k_max = 2;
-        let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
-        assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
-            assert!(index.is_valid());
-            assert!(*k >= k_min);
-            assert!(*k <= k_max);
-        }
-    }
-
-    #[test]
-    fn test_hex_range_distances_2() {
-        let idx = Index::new(0x89283080ddbffff_u64);
-        let k_min = 0;
-        let k_max = 10;
-        let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
-
-        let mut indexes_resolutions: HashMap<H3Index, Vec<u32>> = HashMap::new();
-        for (dist, idx) in indexes.iter() {
-            indexes_resolutions
-                .entry(idx.h3index())
-                .and_modify(|v| v.push(*dist))
-                .or_insert_with(|| vec![*dist]);
-        }
-
-        println!("{:?}", indexes_resolutions);
-        assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
-            assert!(index.is_valid());
-            assert!(*k >= k_min);
-            assert!(*k <= k_max);
-        }
-    }
-
-    #[test]
-    fn serde_index_roundtrip() {
-        let idx = Index::new(0x89283080ddbffff_u64);
-        let serialized_data = serialize(&idx).unwrap();
-        let idx_2: Index = deserialize(&serialized_data).unwrap();
-        assert_eq!(idx, idx_2);
-        assert_eq!(idx.h3index(), idx_2.h3index());
-    }
-
-    /// this test is not really a hard requirement, but it is nice to know
-    /// Index is handled just like an u64
-    #[test]
-    fn serde_index_from_h3index() {
-        let idx: H3Index = 0x89283080ddbffff_u64;
-        let serialized_data = serialize(&idx).unwrap();
-        let idx_2: Index = deserialize(&serialized_data).unwrap();
-        assert_eq!(idx, idx_2.h3index());
-    }
-
-    #[test]
-    fn test_is_neighbor() {
-        let idx: Index = 0x89283080ddbffff_u64.try_into().unwrap();
-        let ring = idx.hex_ring(1).unwrap();
-        let neighbor = ring.first().unwrap();
-        assert!(idx.is_neighbor_to(neighbor));
-        let wrong_neighbor = 0x8a2a1072b59ffff_u64.try_into().unwrap();
-        assert!(!idx.is_neighbor_to(&wrong_neighbor));
-        // Self
-        assert!(!idx.is_neighbor_to(&idx));
-    }
-
-    #[test]
-    fn test_distance_to() {
-        let idx: Index = 0x89283080ddbffff_u64.try_into().unwrap();
-        assert_eq!(idx.distance_to(&idx), 0);
-        let ring = idx.hex_ring(1).unwrap();
-        let neighbor = ring.first().unwrap();
-        assert_eq!(idx.distance_to(&neighbor), 1);
-        let ring = idx.hex_ring(3).unwrap();
-        let neighbor = ring.first().unwrap();
-        assert_eq!(idx.distance_to(&neighbor), 3);
     }
 }

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -3,6 +3,7 @@ use crate::Error;
 use h3ron_h3_sys::H3Index;
 use std::os::raw::c_int;
 
+/// Trait to handle types having a H3 Index like hexagon and edges
 pub trait Index: Sized + PartialEq {
     /// Get the u64 H3 Index address
     fn h3index(&self) -> H3Index;
@@ -13,13 +14,7 @@ pub trait Index: Sized + PartialEq {
     fn new(h3index: H3Index) -> Self;
 
     /// Checks the validity of the index
-    fn validate(&self) -> Result<(), Error> {
-        if !self.is_valid() {
-            Err(Error::InvalidH3Index)
-        } else {
-            Ok(())
-        }
-    }
+    fn validate(&self) -> Result<(), Error>;
 
     /// Gets the index resolution (0-15)
     fn resolution(&self) -> u8 {
@@ -28,7 +23,7 @@ pub trait Index: Sized + PartialEq {
 
     /// Checks the validity of the index
     fn is_valid(&self) -> bool {
-        unsafe { h3ron_h3_sys::h3IsValid(self.h3index()) != 0 }
+        self.validate().is_ok()
     }
 
     /// Checks if `self` is a parent of `other`

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -9,35 +9,26 @@ pub use to_geo::{
 };
 
 use crate::error::check_same_resolution;
-pub use crate::error::Error;
-pub use crate::index::Index;
-pub use crate::index::ToIndex;
-pub use crate::to_h3::ToH3Indexes;
 use crate::util::linestring_to_geocoords;
+pub use {
+    edge_index::EdgeIndex, error::Error, hexagon_index::HexagonIndex, index::Index,
+    to_h3::ToH3Indexes,
+};
 
 #[macro_use]
 mod util;
 pub mod algorithm;
 pub mod collections;
+mod edge_index;
 pub mod error;
 pub mod experimental;
+mod hexagon_index;
 mod index;
 mod to_geo;
 mod to_h3;
 
 pub const H3_MIN_RESOLUTION: u8 = 0_u8;
 pub const H3_MAX_RESOLUTION: u8 = 15_u8;
-
-/// marker trait for indexes, including conversion to a H3Index
-pub trait HasH3Index {
-    fn h3index(&self) -> H3Index;
-}
-
-impl HasH3Index for H3Index {
-    fn h3index(&self) -> H3Index {
-        *self
-    }
-}
 
 pub trait FromH3Index {
     fn from_h3index(h3index: H3Index) -> Self;
@@ -180,8 +171,8 @@ pub fn line_between_indexes(start: H3Index, end: H3Index) -> Result<Vec<H3Index>
 pub fn line(linestring: &LineString<f64>, h3_resolution: u8) -> Result<Vec<H3Index>, Error> {
     let mut h3_indexes_out = vec![];
     for coords in linestring.0.windows(2) {
-        let start_index = Index::from_coordinate(&coords[0], h3_resolution)?;
-        let end_index = Index::from_coordinate(&coords[1], h3_resolution)?;
+        let start_index = HexagonIndex::from_coordinate(&coords[0], h3_resolution)?;
+        let end_index = HexagonIndex::from_coordinate(&coords[1], h3_resolution)?;
 
         let mut segment_indexes =
             line_between_indexes_not_checked(start_index.h3index(), end_index.h3index())?;

--- a/h3ron/src/to_geo.rs
+++ b/h3ron/src/to_geo.rs
@@ -8,7 +8,7 @@ use h3ron_h3_sys::{destroyLinkedPolygon, h3SetToLinkedGeo, radsToDegs, H3Index, 
 
 use crate::algorithm::smoothen_h3_linked_polygon;
 use crate::collections::H3CompactedVec;
-use crate::{HasH3Index, Index};
+use crate::{HexagonIndex, Index};
 
 pub trait ToPolygon {
     fn to_polygon(&self) -> Polygon<f64>;
@@ -23,7 +23,7 @@ pub trait ToLinkedPolygons {
     fn to_linked_polygons(&self, smoothen: bool) -> Vec<Polygon<f64>>;
 }
 
-impl ToLinkedPolygons for Vec<Index> {
+impl ToLinkedPolygons for Vec<HexagonIndex> {
     fn to_linked_polygons(&self, smoothen: bool) -> Vec<Polygon<f64>> {
         let mut h3indexes: Vec<_> = self.iter().map(|i| i.h3index()).collect();
         h3indexes.sort_unstable();
@@ -62,7 +62,7 @@ pub trait ToAlignedLinkedPolygons {
     ) -> Vec<Polygon<f64>>;
 }
 
-impl ToAlignedLinkedPolygons for Vec<Index> {
+impl ToAlignedLinkedPolygons for Vec<HexagonIndex> {
     fn to_aligned_linked_polygons(
         &self,
         align_to_h3_resolution: u8,
@@ -94,7 +94,7 @@ impl ToAlignedLinkedPolygons for Vec<Index> {
 
                 // edge length of the child indexes
                 let edge_length = {
-                    let ring = Index::new(h3indexes[0]).to_polygon();
+                    let ring = HexagonIndex::new(h3indexes[0]).to_polygon();
                     let p1 = Point::from(ring.exterior().0[0]);
                     let p2 = Point::from(ring.exterior().0[1]);
                     p1.euclidean_distance(&p2)
@@ -197,11 +197,11 @@ pub fn to_linked_polygons(h3indexes: &[H3Index], smoothen: bool) -> Vec<Polygon<
 mod tests {
     use geo_types::Coordinate;
 
-    use crate::{Index, ToLinkedPolygons};
+    use crate::{HexagonIndex, ToLinkedPolygons};
 
     #[test]
     fn donut_linked_polygon() {
-        let ring = Index::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+        let ring = HexagonIndex::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
             .unwrap()
             .hex_ring(1)
             .unwrap();

--- a/h3ron/src/to_h3.rs
+++ b/h3ron/src/to_h3.rs
@@ -5,26 +5,26 @@ use geo::{
 use geo_types::{Coordinate, Geometry, Line, Polygon};
 
 use crate::error::check_valid_h3_resolution;
-use crate::{line, polyfill, Error, Index};
+use crate::{line, polyfill, Error, HexagonIndex, Index};
 
 /// convert to indexes at the given resolution
 ///
 /// The output vec may contain duplicate indexes in case of
 /// overlapping input geometries.
 pub trait ToH3Indexes {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error>;
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error>;
 }
 
 impl ToH3Indexes for Polygon<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = polyfill(&self, h3_resolution);
-        Ok(indexes.drain(..).map(Index::new).collect())
+        Ok(indexes.drain(..).map(HexagonIndex::new).collect())
     }
 }
 
 impl ToH3Indexes for MultiPolygon<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         let mut outvec = vec![];
         for poly in self.0.iter() {
             let mut thisvec = poly.to_h3_indexes(h3_resolution)?;
@@ -35,39 +35,39 @@ impl ToH3Indexes for MultiPolygon<f64> {
 }
 
 impl ToH3Indexes for Point<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![Index::from_coordinate(&self.0, h3_resolution)?])
+        Ok(vec![HexagonIndex::from_coordinate(&self.0, h3_resolution)?])
     }
 }
 
 impl ToH3Indexes for MultiPoint<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         let mut outvec = vec![];
         for pt in self.0.iter() {
-            outvec.push(Index::from_coordinate(&pt.0, h3_resolution)?);
+            outvec.push(HexagonIndex::from_coordinate(&pt.0, h3_resolution)?);
         }
         Ok(outvec)
     }
 }
 
 impl ToH3Indexes for Coordinate<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![Index::from_coordinate(&self, h3_resolution)?])
+        Ok(vec![HexagonIndex::from_coordinate(&self, h3_resolution)?])
     }
 }
 
 impl ToH3Indexes for LineString<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = line(&self, h3_resolution)?;
-        Ok(indexes.drain(..).map(Index::new).collect())
+        Ok(indexes.drain(..).map(HexagonIndex::new).collect())
     }
 }
 
 impl ToH3Indexes for MultiLineString<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         let mut outvec = vec![];
         for ls in self.0.iter() {
             let mut thisvec = ls.to_h3_indexes(h3_resolution)?;
@@ -78,25 +78,25 @@ impl ToH3Indexes for MultiLineString<f64> {
 }
 
 impl ToH3Indexes for Rect<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         self.to_polygon().to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for Triangle<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         self.to_polygon().to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for Line<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         LineString::from(vec![self.start, self.end]).to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for GeometryCollection<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         let mut outvec = vec![];
         for geom in self.0.iter() {
             let mut thisvec = geom.to_h3_indexes(h3_resolution)?;
@@ -107,7 +107,7 @@ impl ToH3Indexes for GeometryCollection<f64> {
 }
 
 impl ToH3Indexes for Geometry<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<Index>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
         match self {
             Geometry::Point(pt) => pt.to_h3_indexes(h3_resolution),
             Geometry::Line(l) => l.to_h3_indexes(h3_resolution),

--- a/h3ron/src/util.rs
+++ b/h3ron/src/util.rs
@@ -1,8 +1,7 @@
 use geo_types::{Coordinate, LineString, Point};
 
+use crate::Index;
 use h3ron_h3_sys::{degsToRads, GeoCoord, H3Index};
-
-use crate::index::Index;
 
 /// filter out 0 values ( = positions in the vec not used to store h3indexes)
 macro_rules! remove_zero_indexes_from_vec {
@@ -12,11 +11,8 @@ macro_rules! remove_zero_indexes_from_vec {
 }
 
 #[inline]
-pub(crate) fn drain_h3indexes_to_indexes(mut v: Vec<H3Index>) -> Vec<Index> {
-    v.drain(..)
-        .filter(|h3i| *h3i != 0)
-        .map(Index::new)
-        .collect()
+pub(crate) fn drain_h3indexes_to_indexes<T: Index>(mut v: Vec<H3Index>) -> Vec<T> {
+    v.drain(..).filter(|h3i| *h3i != 0).map(T::new).collect()
 }
 
 pub(crate) unsafe fn coordinate_to_geocoord(c: &Coordinate<f64>) -> GeoCoord {

--- a/h3ronpy/src/error.rs
+++ b/h3ronpy/src/error.rs
@@ -11,8 +11,8 @@ impl<T> IntoPyResult<T> for Result<T, h3ron::Error> {
             Ok(v) => Ok(v),
             Err(err) => match err {
                 h3ron::Error::InvalidInput
-                | h3ron::Error::MixedResolutions
-                | h3ron::Error::InvalidH3Resolution
+                | h3ron::Error::MixedResolutions(..)
+                | h3ron::Error::InvalidH3Resolution(_)
                 | h3ron::Error::InvalidH3Hexagon(_)
                 | h3ron::Error::InvalidH3Edge(_) => Err(PyValueError::new_err(err.to_string())),
 

--- a/h3ronpy/src/error.rs
+++ b/h3ronpy/src/error.rs
@@ -13,7 +13,8 @@ impl<T> IntoPyResult<T> for Result<T, h3ron::Error> {
                 h3ron::Error::InvalidInput
                 | h3ron::Error::MixedResolutions
                 | h3ron::Error::InvalidH3Resolution
-                | h3ron::Error::InvalidH3Index => Err(PyValueError::new_err(err.to_string())),
+                | h3ron::Error::InvalidH3Hexagon(_)
+                | h3ron::Error::InvalidH3Edge(_) => Err(PyValueError::new_err(err.to_string())),
 
                 h3ron::Error::PentagonalDistortion
                 | h3ron::Error::NoLocalIJCoordinates

--- a/h3ronpy/src/polygon.rs
+++ b/h3ronpy/src/polygon.rs
@@ -6,7 +6,7 @@ use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
-use h3ron::{Index, ToAlignedLinkedPolygons, ToLinkedPolygons};
+use h3ron::{HexagonIndex, Index, ToAlignedLinkedPolygons, ToLinkedPolygons};
 
 #[pyclass]
 pub struct Polygon {
@@ -21,7 +21,7 @@ impl Polygon {
         let h3indexes: Vec<_> = h3index_arr
             .as_array()
             .iter()
-            .map(|hi| Index::new(*hi))
+            .map(|hi| HexagonIndex::new(*hi))
             .collect();
 
         h3indexes
@@ -41,7 +41,7 @@ impl Polygon {
         let h3indexes: Vec<_> = h3index_arr
             .as_array()
             .iter()
-            .map(|hi| Index::new(*hi))
+            .map(|hi| HexagonIndex::new(*hi))
             .collect();
 
         h3indexes

--- a/h3ronpy/src/vector.rs
+++ b/h3ronpy/src/vector.rs
@@ -5,7 +5,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::{prelude::*, wrap_pyfunction};
 use rayon::prelude::*;
 
-use h3ron::{compact, HasH3Index, ToH3Indexes};
+use h3ron::{compact, Index, ToH3Indexes};
 
 use crate::error::IntoPyResult;
 


### PR DESCRIPTION
To be able to handle both Hexagon and edge indexes:
- I renamed the current `Index` struct to `HexagonIndex`
- I created an identic struct `EdgeIndex`
- I moved common code to a `Index` trait
- I removed the `HasH3Index` trait and moved its code to `Index`

New features:
- Edge length methods
- Edge validation
- Get edge between two hexagons
- Get an hexagon edges
- Edges can retrieve their origin and destination hexagons

Other changes:
- Error improvements