### PR TITLE
Semantics and error improvements

### DIFF
--- a/h3ron-ndarray/examples/h3ify_r_tiff.rs
+++ b/h3ron-ndarray/examples/h3ify_r_tiff.rs
@@ -3,7 +3,7 @@ use gdal::{
     Dataset, Driver,
 };
 
-use h3ron::{HexagonIndex, Index, ToPolygon};
+use h3ron::{H3Cell, Index, ToPolygon};
 use h3ron_ndarray::{AxisOrder, H3Converter, ResolutionSearchMode::SmallerThanPixel, Transform};
 use std::convert::TryFrom;
 
@@ -47,7 +47,7 @@ fn main() {
 
     results.iter().for_each(|(_value, index_stack)| {
         for h3index in index_stack.iter_compacted_indexes() {
-            let index = HexagonIndex::try_from(h3index).unwrap();
+            let index = H3Cell::try_from(h3index).unwrap();
             let mut ft = Feature::new(&defn).unwrap();
             ft.set_geometry(index.to_polygon().to_gdal().unwrap())
                 .unwrap();

--- a/h3ron-ndarray/src/array.rs
+++ b/h3ron-ndarray/src/array.rs
@@ -6,7 +6,7 @@ use geo_types::{Coordinate, Rect};
 use log::debug;
 use ndarray::{parallel::prelude::*, ArrayView2, Axis};
 
-use h3ron::{collections::H3CompactedVec, polyfill, HexagonIndex, Index, ToCoordinate};
+use h3ron::{collections::H3CompactedVec, polyfill, H3Cell, Index, ToCoordinate};
 
 use crate::resolution::{nearest_h3_resolution, ResolutionSearchMode};
 use crate::{error::Error, transform::Transform};
@@ -290,7 +290,7 @@ where
                     // find the array element for the coordinate of the h3ron index
                     let arr_coord = {
                         let transformed =
-                            &inverse_transform * &HexagonIndex::new(h3index).to_coordinate();
+                            &inverse_transform * &H3Cell::new(h3index).to_coordinate();
 
                         match self.axis_order {
                             AxisOrder::XY => [

--- a/h3ron-ndarray/src/resolution.rs
+++ b/h3ron-ndarray/src/resolution.rs
@@ -7,7 +7,7 @@ use crate::{
     AxisOrder,
 };
 
-use h3ron::{HexagonIndex, ToPolygon, H3_MAX_RESOLUTION, H3_MIN_RESOLUTION};
+use h3ron::{H3Cell, ToPolygon, H3_MAX_RESOLUTION, H3_MIN_RESOLUTION};
 
 pub enum ResolutionSearchMode {
     /// chose the h3 resolution where the difference in the area of a pixel and the h3index is
@@ -50,7 +50,7 @@ pub fn nearest_h3_resolution(
         // calculate the area of the center index to avoid using the approximate values
         // of the h3ron hexArea functions
         let area_h3_index = area_linearring(
-            HexagonIndex::from_coordinate_unchecked(&center_of_array, h3_res)
+            H3Cell::from_coordinate_unchecked(&center_of_array, h3_res)
                 .to_polygon()
                 .exterior(),
         );

--- a/h3ron/Cargo.toml
+++ b/h3ron/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/nmandery/h3ron"
 [dependencies]
 geo = "^0.16"
 itertools = "^0.10"
+# Error handling
+thiserror = "1.0"
 
 [dependencies.h3ron-h3-sys]
 path = "../h3ron-h3-sys"

--- a/h3ron/src/algorithm.rs
+++ b/h3ron/src/algorithm.rs
@@ -79,11 +79,11 @@ mod tests {
     use geo_types::Coordinate;
 
     use crate::algorithm::smoothen_h3_linked_polygon;
-    use crate::{HexagonIndex, ToLinkedPolygons};
+    use crate::{H3Cell, ToLinkedPolygons};
 
     #[test]
     fn smooth_donut_linked_polygon() {
-        let ring = HexagonIndex::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+        let ring = H3Cell::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
             .unwrap()
             .hex_ring(4)
             .unwrap();

--- a/h3ron/src/collections.rs
+++ b/h3ron/src/collections.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use h3ron_h3_sys::H3Index;
 
-use crate::hexagon_index::HexagonIndex;
+use crate::H3Cell;
 use crate::{compact, Index, H3_MAX_RESOLUTION, H3_MIN_RESOLUTION};
 
 const H3_RESOLUTION_RANGE_USIZE: RangeInclusive<usize> =
@@ -95,7 +95,7 @@ impl<'a> H3CompactedVec {
         if self.is_empty() {
             return false;
         }
-        let mut index = HexagonIndex::new(h3index);
+        let mut index = H3Cell::new(h3index);
         for r in index.resolution()..=H3_MIN_RESOLUTION {
             index = match index.get_parent(r) {
                 Ok(i) => i,
@@ -112,7 +112,7 @@ impl<'a> H3CompactedVec {
     ///
     /// will trigger a re-compacting when `compact` is set
     pub fn add_index(&mut self, h3_index: H3Index, compact: bool) {
-        let resolution = HexagonIndex::new(h3_index).resolution();
+        let resolution = H3Cell::new(h3_index).resolution();
         self.add_index_to_resolution(h3_index, resolution, compact);
     }
 
@@ -132,7 +132,7 @@ impl<'a> H3CompactedVec {
     pub fn add_indexes(&mut self, h3_indexes: &[H3Index], compact: bool) {
         let mut resolutions_touched = HashSet::new();
         for h3_index in h3_indexes {
-            let res = HexagonIndex::new(*h3_index).resolution() as usize;
+            let res = H3Cell::new(*h3_index).resolution() as usize;
             resolutions_touched.insert(res);
             self.indexes_by_resolution[res].push(*h3_index);
         }
@@ -235,7 +235,7 @@ impl<'a> H3CompactedVec {
             indexes_to_compact.dedup();
             let compacted = compact(&indexes_to_compact);
             for h3_index in compacted {
-                let res = HexagonIndex::new(h3_index).resolution() as usize;
+                let res = H3Cell::new(h3_index).resolution() as usize;
                 resolutions_touched.insert(res);
                 self.indexes_by_resolution[res].push(h3_index);
             }
@@ -262,7 +262,7 @@ impl<'a> H3CompactedVec {
             for r in (lowest_res + 1)..=(H3_MAX_RESOLUTION as usize) {
                 let mut orig_h3indexes = std::mem::take(&mut self.indexes_by_resolution[r]);
                 orig_h3indexes.drain(..).for_each(|h3index| {
-                    let index = HexagonIndex::new(h3index);
+                    let index = H3Cell::new(h3index);
                     if !(lowest_res..r).any(|parent_res| {
                         known_indexes
                             .contains(&index.get_parent_unchecked(parent_res as u8).h3index())
@@ -290,8 +290,8 @@ impl FromIterator<H3Index> for H3CompactedVec {
     }
 }
 
-impl FromIterator<HexagonIndex> for H3CompactedVec {
-    fn from_iter<T: IntoIterator<Item = HexagonIndex>>(iter: T) -> Self {
+impl FromIterator<H3Cell> for H3CompactedVec {
+    fn from_iter<T: IntoIterator<Item = H3Cell>>(iter: T) -> Self {
         let mut cv = Self::new();
         for index in iter {
             cv.add_index(index.h3index(), false);
@@ -361,7 +361,7 @@ impl<'a> Iterator for H3CompactedVecUncompactedIterator<'a> {
                 [self.current_resolution]
                 .get(self.current_pos)
             {
-                self.current_uncompacted = HexagonIndex::new(*next_parent)
+                self.current_uncompacted = H3Cell::new(*next_parent)
                     .get_children(self.iteration_resolution as u8)
                     .iter()
                     .map(|i| i.h3index())

--- a/h3ron/src/error.rs
+++ b/h3ron/src/error.rs
@@ -1,43 +1,36 @@
-use crate::{HexagonIndex, Index, H3_MAX_RESOLUTION};
-use h3ron_h3_sys::H3Index;
 use std::convert::TryFrom;
-use std::fmt;
+use thiserror::Error as DeriveError;
 
-#[derive(Debug)]
+use h3ron_h3_sys::H3Index;
+
+use crate::{H3Cell, Index, H3_MAX_RESOLUTION};
+
+#[derive(Debug, DeriveError)]
 pub enum Error {
+    #[error("Local IJ coordinates not found")]
     NoLocalIJCoordinates,
+    #[error("Invalid input")]
     InvalidInput,
+    #[error("Invalid H3 Hexagon index {0:x}")]
     InvalidH3Hexagon(H3Index),
+    #[error("Invalid H3 Edge index {0:x}")]
     InvalidH3Edge(H3Index),
+    #[error("Pentagonal distortion")]
     PentagonalDistortion,
+    #[error("Line is not computable")]
     LineNotComputable,
+    #[error("Mixed H3 resolutions: {0} and {1}")]
     MixedResolutions(u8, u8),
+    #[error("Unsupported operation")]
     UnsupportedOperation,
+    #[error("Invalid H3 resolution: {0}")]
     InvalidH3Resolution(u8),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidInput => write!(f, "invalid input"),
-            Self::InvalidH3Hexagon(i) => write!(f, "invalid h3ron hexagon index {:x}", i),
-            Self::InvalidH3Edge(i) => write!(f, "invalid h3ron edge index {:x}", i),
-            Self::NoLocalIJCoordinates => write!(f, "no local IJ coordinates found"),
-            Self::PentagonalDistortion => write!(f, "pentagonal distortion"),
-            Self::LineNotComputable => write!(f, "line is not computable"),
-            Self::MixedResolutions(r1, r2) => write!(f, "mixed h3 resolutions: {} and {}", r1, r2),
-            Self::UnsupportedOperation => write!(f, "unsupported operation"),
-            Self::InvalidH3Resolution(r) => write!(f, "invalid h3 resolution: {}", r),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
 /// ensure two indexes have the same resolution
 pub fn check_same_resolution(index0: H3Index, index1: H3Index) -> Result<(), Error> {
-    let res0 = HexagonIndex::try_from(index0)?.resolution();
-    let res1 = HexagonIndex::try_from(index1)?.resolution();
+    let res0 = H3Cell::try_from(index0)?.resolution();
+    let res1 = H3Cell::try_from(index1)?.resolution();
     if res0 != res1 {
         Err(Error::MixedResolutions(res0, res1))
     } else {

--- a/h3ron/src/experimental.rs
+++ b/h3ron/src/experimental.rs
@@ -3,7 +3,7 @@ use std::result::Result;
 use h3ron_h3_sys::H3Index;
 
 use crate::error::Error;
-use crate::hexagon_index::HexagonIndex;
+use crate::H3Cell;
 use crate::Index;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -18,7 +18,7 @@ impl Default for CoordIJ {
     }
 }
 
-pub fn h3_to_local_ij(origin_index: &HexagonIndex, index: &HexagonIndex) -> Result<CoordIJ, Error> {
+pub fn h3_to_local_ij(origin_index: &H3Cell, index: &H3Cell) -> Result<CoordIJ, Error> {
     unsafe {
         let mut cij = h3ron_h3_sys::CoordIJ { i: 0, j: 0 };
         if h3ron_h3_sys::experimentalH3ToLocalIj(origin_index.h3index(), index.h3index(), &mut cij)
@@ -31,10 +31,7 @@ pub fn h3_to_local_ij(origin_index: &HexagonIndex, index: &HexagonIndex) -> Resu
     }
 }
 
-pub fn local_ij_to_h3(
-    origin_index: &HexagonIndex,
-    coordij: &CoordIJ,
-) -> Result<HexagonIndex, Error> {
+pub fn local_ij_to_h3(origin_index: &H3Cell, coordij: &CoordIJ) -> Result<H3Cell, Error> {
     unsafe {
         let cij = h3ron_h3_sys::CoordIJ {
             i: coordij.i,
@@ -44,7 +41,7 @@ pub fn local_ij_to_h3(
         if h3ron_h3_sys::experimentalLocalIjToH3(origin_index.h3index(), &cij, &mut h3_index_out)
             == 0
         {
-            Ok(HexagonIndex::new(h3_index_out))
+            Ok(H3Cell::new(h3_index_out))
         } else {
             Err(Error::NoLocalIJCoordinates)
         }
@@ -54,12 +51,12 @@ pub fn local_ij_to_h3(
 #[cfg(test)]
 mod tests {
     use crate::experimental::{h3_to_local_ij, local_ij_to_h3};
-    use crate::hexagon_index::HexagonIndex;
+    use crate::h3_cell::H3Cell;
     use std::convert::TryFrom;
 
     #[test]
     fn test_local_ij() {
-        let origin_index = HexagonIndex::try_from(0x89283080ddbffff_u64).unwrap();
+        let origin_index = H3Cell::try_from(0x89283080ddbffff_u64).unwrap();
         let ring = origin_index.k_ring(1);
         assert_ne!(ring.len(), 0);
         let other_index = ring.iter().find(|i| **i != origin_index).unwrap().clone();

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -10,19 +10,16 @@ pub use to_geo::{
 
 use crate::error::check_same_resolution;
 use crate::util::linestring_to_geocoords;
-pub use {
-    edge_index::EdgeIndex, error::Error, hexagon_index::HexagonIndex, index::Index,
-    to_h3::ToH3Indexes,
-};
+pub use {error::Error, h3_cell::H3Cell, h3_edge::H3Edge, index::Index, to_h3::ToH3Indexes};
 
 #[macro_use]
 mod util;
 pub mod algorithm;
 pub mod collections;
-mod edge_index;
 pub mod error;
 pub mod experimental;
-mod hexagon_index;
+mod h3_cell;
+mod h3_edge;
 mod index;
 mod to_geo;
 mod to_h3;
@@ -171,8 +168,8 @@ pub fn line_between_indexes(start: H3Index, end: H3Index) -> Result<Vec<H3Index>
 pub fn line(linestring: &LineString<f64>, h3_resolution: u8) -> Result<Vec<H3Index>, Error> {
     let mut h3_indexes_out = vec![];
     for coords in linestring.0.windows(2) {
-        let start_index = HexagonIndex::from_coordinate(&coords[0], h3_resolution)?;
-        let end_index = HexagonIndex::from_coordinate(&coords[1], h3_resolution)?;
+        let start_index = H3Cell::from_coordinate(&coords[0], h3_resolution)?;
+        let end_index = H3Cell::from_coordinate(&coords[1], h3_resolution)?;
 
         let mut segment_indexes =
             line_between_indexes_not_checked(start_index.h3index(), end_index.h3index())?;

--- a/h3ron/src/to_geo.rs
+++ b/h3ron/src/to_geo.rs
@@ -8,7 +8,7 @@ use h3ron_h3_sys::{destroyLinkedPolygon, h3SetToLinkedGeo, radsToDegs, H3Index, 
 
 use crate::algorithm::smoothen_h3_linked_polygon;
 use crate::collections::H3CompactedVec;
-use crate::{HexagonIndex, Index};
+use crate::{H3Cell, Index};
 
 pub trait ToPolygon {
     fn to_polygon(&self) -> Polygon<f64>;
@@ -23,7 +23,7 @@ pub trait ToLinkedPolygons {
     fn to_linked_polygons(&self, smoothen: bool) -> Vec<Polygon<f64>>;
 }
 
-impl ToLinkedPolygons for Vec<HexagonIndex> {
+impl ToLinkedPolygons for Vec<H3Cell> {
     fn to_linked_polygons(&self, smoothen: bool) -> Vec<Polygon<f64>> {
         let mut h3indexes: Vec<_> = self.iter().map(|i| i.h3index()).collect();
         h3indexes.sort_unstable();
@@ -62,7 +62,7 @@ pub trait ToAlignedLinkedPolygons {
     ) -> Vec<Polygon<f64>>;
 }
 
-impl ToAlignedLinkedPolygons for Vec<HexagonIndex> {
+impl ToAlignedLinkedPolygons for Vec<H3Cell> {
     fn to_aligned_linked_polygons(
         &self,
         align_to_h3_resolution: u8,
@@ -94,7 +94,7 @@ impl ToAlignedLinkedPolygons for Vec<HexagonIndex> {
 
                 // edge length of the child indexes
                 let edge_length = {
-                    let ring = HexagonIndex::new(h3indexes[0]).to_polygon();
+                    let ring = H3Cell::new(h3indexes[0]).to_polygon();
                     let p1 = Point::from(ring.exterior().0[0]);
                     let p2 = Point::from(ring.exterior().0[1]);
                     p1.euclidean_distance(&p2)
@@ -197,11 +197,11 @@ pub fn to_linked_polygons(h3indexes: &[H3Index], smoothen: bool) -> Vec<Polygon<
 mod tests {
     use geo_types::Coordinate;
 
-    use crate::{HexagonIndex, ToLinkedPolygons};
+    use crate::{H3Cell, ToLinkedPolygons};
 
     #[test]
     fn donut_linked_polygon() {
-        let ring = HexagonIndex::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
+        let ring = H3Cell::from_coordinate(&Coordinate::from((23.3, 12.3)), 6)
             .unwrap()
             .hex_ring(1)
             .unwrap();

--- a/h3ron/src/to_h3.rs
+++ b/h3ron/src/to_h3.rs
@@ -5,26 +5,26 @@ use geo::{
 use geo_types::{Coordinate, Geometry, Line, Polygon};
 
 use crate::error::check_valid_h3_resolution;
-use crate::{line, polyfill, Error, HexagonIndex, Index};
+use crate::{line, polyfill, Error, H3Cell, Index};
 
 /// convert to indexes at the given resolution
 ///
 /// The output vec may contain duplicate indexes in case of
 /// overlapping input geometries.
 pub trait ToH3Indexes {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error>;
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error>;
 }
 
 impl ToH3Indexes for Polygon<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = polyfill(&self, h3_resolution);
-        Ok(indexes.drain(..).map(HexagonIndex::new).collect())
+        Ok(indexes.drain(..).map(H3Cell::new).collect())
     }
 }
 
 impl ToH3Indexes for MultiPolygon<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         let mut outvec = vec![];
         for poly in self.0.iter() {
             let mut thisvec = poly.to_h3_indexes(h3_resolution)?;
@@ -35,39 +35,39 @@ impl ToH3Indexes for MultiPolygon<f64> {
 }
 
 impl ToH3Indexes for Point<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![HexagonIndex::from_coordinate(&self.0, h3_resolution)?])
+        Ok(vec![H3Cell::from_coordinate(&self.0, h3_resolution)?])
     }
 }
 
 impl ToH3Indexes for MultiPoint<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         let mut outvec = vec![];
         for pt in self.0.iter() {
-            outvec.push(HexagonIndex::from_coordinate(&pt.0, h3_resolution)?);
+            outvec.push(H3Cell::from_coordinate(&pt.0, h3_resolution)?);
         }
         Ok(outvec)
     }
 }
 
 impl ToH3Indexes for Coordinate<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
-        Ok(vec![HexagonIndex::from_coordinate(&self, h3_resolution)?])
+        Ok(vec![H3Cell::from_coordinate(&self, h3_resolution)?])
     }
 }
 
 impl ToH3Indexes for LineString<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         check_valid_h3_resolution(h3_resolution)?;
         let mut indexes = line(&self, h3_resolution)?;
-        Ok(indexes.drain(..).map(HexagonIndex::new).collect())
+        Ok(indexes.drain(..).map(H3Cell::new).collect())
     }
 }
 
 impl ToH3Indexes for MultiLineString<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         let mut outvec = vec![];
         for ls in self.0.iter() {
             let mut thisvec = ls.to_h3_indexes(h3_resolution)?;
@@ -78,25 +78,25 @@ impl ToH3Indexes for MultiLineString<f64> {
 }
 
 impl ToH3Indexes for Rect<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         self.to_polygon().to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for Triangle<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         self.to_polygon().to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for Line<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         LineString::from(vec![self.start, self.end]).to_h3_indexes(h3_resolution)
     }
 }
 
 impl ToH3Indexes for GeometryCollection<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         let mut outvec = vec![];
         for geom in self.0.iter() {
             let mut thisvec = geom.to_h3_indexes(h3_resolution)?;
@@ -107,7 +107,7 @@ impl ToH3Indexes for GeometryCollection<f64> {
 }
 
 impl ToH3Indexes for Geometry<f64> {
-    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<HexagonIndex>, Error> {
+    fn to_h3_indexes(&self, h3_resolution: u8) -> Result<Vec<H3Cell>, Error> {
         match self {
             Geometry::Point(pt) => pt.to_h3_indexes(h3_resolution),
             Geometry::Line(l) => l.to_h3_indexes(h3_resolution),

--- a/h3ronpy/src/polygon.rs
+++ b/h3ronpy/src/polygon.rs
@@ -6,7 +6,7 @@ use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
-use h3ron::{HexagonIndex, Index, ToAlignedLinkedPolygons, ToLinkedPolygons};
+use h3ron::{H3Cell, Index, ToAlignedLinkedPolygons, ToLinkedPolygons};
 
 #[pyclass]
 pub struct Polygon {
@@ -21,7 +21,7 @@ impl Polygon {
         let h3indexes: Vec<_> = h3index_arr
             .as_array()
             .iter()
-            .map(|hi| HexagonIndex::new(*hi))
+            .map(|hi| H3Cell::new(*hi))
             .collect();
 
         h3indexes
@@ -41,7 +41,7 @@ impl Polygon {
         let h3indexes: Vec<_> = h3index_arr
             .as_array()
             .iter()
-            .map(|hi| HexagonIndex::new(*hi))
+            .map(|hi| H3Cell::new(*hi))
             .collect();
 
         h3indexes


### PR DESCRIPTION
After reading some documentation I noticed that my last MR (#10 ) was using different names than H3.
So I renamed:
- `HexagonIndex` into `H3Cell`
- `EdgeIndex` into `H3Edge`

I also added the `thiserror` crate for simpler error definition but maybe you don't want that