### PR TITLE
H3Cell and H3Edge debug in hexadecimal

### DIFF
--- a/h3ron/src/h3_cell.rs
+++ b/h3ron/src/h3_cell.rs
@@ -13,10 +13,17 @@ use crate::error::Error;
 use crate::index::Index;
 use crate::util::{coordinate_to_geocoord, drain_h3indexes_to_indexes, point_to_geocoord};
 use crate::{max_k_ring_size, AreaUnits, FromH3Index, H3Edge, ToCoordinate, ToPolygon};
+use std::fmt::{self, Debug, Formatter};
 
 /// H3 Index representing a H3 Cell (hexagon)
-#[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
+#[derive(PartialOrd, PartialEq, Clone, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
 pub struct H3Cell(H3Index);
+
+impl Debug for H3Cell {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "H3Cell({})", self.to_string())
+    }
+}
 
 /// convert to index including validation
 impl TryFrom<u64> for H3Cell {
@@ -329,6 +336,12 @@ mod tests {
             H3Cell::try_from(h3index).unwrap().to_string(),
             "89283080ddbffff".to_string()
         );
+    }
+
+    #[test]
+    fn test_debug_hexadecimal() {
+        let cell = H3Cell::new(0x89283080ddbffff_u64);
+        assert_eq!(format!("{:?}", cell), "H3Cell(89283080ddbffff)".to_string())
     }
 
     #[test]

--- a/h3ron/src/h3_edge.rs
+++ b/h3ron/src/h3_edge.rs
@@ -4,12 +4,19 @@ use h3ron_h3_sys::H3Index;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::ffi::CString;
+use std::fmt::{self, Debug, Formatter};
 use std::os::raw::c_int;
 use std::str::FromStr;
 
 /// H3 Index representing an Unidirectional H3 edge
-#[derive(PartialOrd, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
+#[derive(PartialOrd, PartialEq, Clone, Serialize, Deserialize, Hash, Eq, Ord, Copy)]
 pub struct H3Edge(H3Index);
+
+impl Debug for H3Edge {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "H3Edge({})", self.to_string())
+    }
+}
 
 /// convert to index including validation
 impl TryFrom<u64> for H3Edge {
@@ -160,5 +167,14 @@ mod tests {
         let parent_1 = edge.get_parent(1).unwrap();
         assert_eq!(parent_1.resolution(), 1);
         assert!(edge.is_child_of(&parent_1));
+    }
+
+    #[test]
+    fn debug_hexadecimal() {
+        let edge = H3Edge::new(0x149283080ddbffff);
+        assert_eq!(
+            format!("{:?}", edge),
+            "H3Edge(149283080ddbffff)".to_string()
+        )
     }
 }


### PR DESCRIPTION
I added a custom Debug implementation for `H3Cell` and `H3Edge` to avoid seeing the `H3Index` in decimal which is useless