### PR TITLE
Clippy fixes

### DIFF
--- a/h3ron-graph/src/formats/osm.rs
+++ b/h3ron-graph/src/formats/osm.rs
@@ -90,7 +90,7 @@ where
                             h3indexes.dedup();
 
                             for window in h3indexes.windows(2) {
-                                let edge = window[0].unidirectional_edge_to(&window[1])?;
+                                let edge = window[0].unidirectional_edge_to(window[1])?;
                                 let edge_props =
                                     self.way_analyzer.way_edge_properties(edge, &way_props);
 

--- a/h3ron-graph/src/graph/h3edge.rs
+++ b/h3ron-graph/src/graph/h3edge.rs
@@ -75,7 +75,7 @@ where
         cell_to: H3Cell,
         weight: W,
     ) -> Result<(), Error> {
-        let edge = cell_from.unidirectional_edge_to(&cell_to)?;
+        let edge = cell_from.unidirectional_edge_to(cell_to)?;
         self.add_edge(edge, weight)
     }
 
@@ -240,7 +240,7 @@ where
                     } else {
                         Some(
                             cell_from
-                                .unidirectional_edge_to(&cell_to)
+                                .unidirectional_edge_to(cell_to)
                                 .map(|downsamled_edge| (downsamled_edge, *weight)),
                         )
                     }

--- a/h3ron/src/algorithm.rs
+++ b/h3ron/src/algorithm.rs
@@ -28,8 +28,8 @@ pub(crate) fn smoothen_h3_coordinates(in_coords: &[Coordinate<f64>]) -> Vec<Coor
             out.push(*in_coords.first().unwrap());
         }
         let apply_window = |c1: &Coordinate<f64>, c2: &Coordinate<f64>| Coordinate {
-            x: 0.5f64.mul_add(c1.x, 0.5 * c2.x),
-            y: 0.5f64.mul_add(c1.y, 0.5 * c2.y),
+            x: 0.5_f64.mul_add(c1.x, 0.5 * c2.x),
+            y: 0.5_f64.mul_add(c1.y, 0.5 * c2.y),
         };
         in_coords.windows(2).for_each(|window| {
             out.push(apply_window(&window[0], &window[1]));

--- a/h3ron/src/collections/indexvec.rs
+++ b/h3ron/src/collections/indexvec.rs
@@ -120,15 +120,15 @@ impl<T: FromH3Index + Index> IndexVec<T> {
     }
 
     pub fn append(&mut self, other: &mut Self) {
-        self.inner_vec.append(&mut other.inner_vec)
+        self.inner_vec.append(&mut other.inner_vec);
     }
 
     pub fn dedup(&mut self) {
-        self.inner_vec.dedup()
+        self.inner_vec.dedup();
     }
 
     pub fn sort_unstable(&mut self) {
-        self.inner_vec.sort_unstable()
+        self.inner_vec.sort_unstable();
     }
 
     pub fn count(&self) -> usize {
@@ -136,7 +136,7 @@ impl<T: FromH3Index + Index> IndexVec<T> {
     }
 
     pub fn push(&mut self, item: T) {
-        self.inner_vec.push(item.h3index())
+        self.inner_vec.push(item.h3index());
     }
 }
 
@@ -232,9 +232,9 @@ impl<T: FromH3Index + Index> TryFrom<Vec<H3Index>> for IndexVec<T> {
     type Error = Error;
 
     fn try_from(h3index_vec: Vec<H3Index>) -> Result<Self, Self::Error> {
-        for h3index in h3index_vec.iter() {
+        for h3index in &h3index_vec {
             let value = T::from_h3index(*h3index);
-            value.validate()?
+            value.validate()?;
         }
         Ok(Self {
             inner_vec: h3index_vec,

--- a/h3ron/src/collections/mod.rs
+++ b/h3ron/src/collections/mod.rs
@@ -1,7 +1,7 @@
 //! # Hashing
 //!
-//! This crate uses `ahash` for its HashMap and HashSets. This hash hash shown in benchmarks to be
-//! approx. 10% faster with H3 indexes than the standard SipHash used in rust. On the other hand it shows a higher
+//! This crate uses `ahash` for its `HashMap` and `HashSets`. This hash hash shown in benchmarks to be
+//! approx. 10% faster with H3 indexes than the standard `SipHash` used in rust. On the other hand it shows a higher
 //! fluctuation in runtime during benchmarks. Interestingly the normally very fast
 //! `rustc_hash` (uses `FxHash`) seems to be very slow with H3 cells and edges. Mostly noticed during
 //! deserialization of graphs, but also during using the `pathfinding` crate which uses

--- a/h3ron/src/error.rs
+++ b/h3ron/src/error.rs
@@ -39,10 +39,10 @@ pub enum Error {
 pub fn check_same_resolution(cell0: H3Cell, cell1: H3Cell) -> Result<(), Error> {
     let res0 = cell0.resolution();
     let res1 = cell1.resolution();
-    if res0 != res1 {
-        Err(Error::MixedResolutions(res0, res1))
-    } else {
+    if res0 == res1 {
         Ok(())
+    } else {
+        Err(Error::MixedResolutions(res0, res1))
     }
 }
 

--- a/h3ron/src/h3_cell.rs
+++ b/h3ron/src/h3_cell.rs
@@ -81,7 +81,7 @@ impl H3Cell {
     pub fn from_point_unchecked(pt: &Point<f64>, h3_resolution: u8) -> Self {
         let h3index = unsafe {
             let gc = point_to_geocoord(pt);
-            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
+            h3ron_h3_sys::geoToH3(&gc, c_int::from(h3_resolution))
         };
         Self::new(h3index)
     }
@@ -105,7 +105,7 @@ impl H3Cell {
     pub fn from_coordinate_unchecked(c: &Coordinate<f64>, h3_resolution: u8) -> Self {
         let h3index = unsafe {
             let gc = coordinate_to_geocoord(c);
-            h3ron_h3_sys::geoToH3(&gc, h3_resolution as c_int)
+            h3ron_h3_sys::geoToH3(&gc, c_int::from(h3_resolution))
         };
         Self::new(h3index)
     }
@@ -184,7 +184,7 @@ impl H3Cell {
                 k_max as c_int,
                 h3_indexes_out.as_mut_ptr(),
                 distances_out.as_mut_ptr(),
-            )
+            );
         };
         self.associate_index_distances(h3_indexes_out, distances_out, k_min)
     }
@@ -216,7 +216,7 @@ impl H3Cell {
     }
 
     fn associate_index_distances(
-        &self,
+        self,
         mut h3_indexes_out: Vec<H3Index>,
         distances_out: Vec<c_int>,
         k_min: u32,
@@ -271,7 +271,7 @@ impl H3Cell {
             h3ron_h3_sys::getH3UnidirectionalEdgesFromHexagon(
                 self.h3index(),
                 index_vec.as_mut_ptr(),
-            )
+            );
         };
         index_vec
     }
@@ -284,7 +284,7 @@ impl H3Cell {
     /// assert_eq!(15047.5, H3Cell::area_m2(10));
     /// ```
     pub fn area_m2(resolution: u8) -> f64 {
-        unsafe { h3ron_h3_sys::hexAreaM2(resolution as i32) }
+        unsafe { h3ron_h3_sys::hexAreaM2(i32::from(resolution)) }
     }
 
     /// get the average cell area at `resolution` in square kilometers.
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn test_debug_hexadecimal() {
         let cell = H3Cell::new(0x89283080ddbffff_u64);
-        assert_eq!(format!("{:?}", cell), "H3Cell(89283080ddbffff)".to_string())
+        assert_eq!(format!("{:?}", cell), "H3Cell(89283080ddbffff)".to_string());
     }
 
     #[test]
@@ -435,7 +435,7 @@ mod tests {
         let k_max = 2;
         let indexes = idx.k_ring_distances(k_min, k_max);
         assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
+        for (k, index) in &indexes {
             assert!(index.is_valid());
             assert!(*k >= k_min);
             assert!(*k <= k_max);
@@ -449,7 +449,7 @@ mod tests {
         let k_max = 2;
         let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
         assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
+        for (k, index) in &indexes {
             assert!(index.is_valid());
             assert!(*k >= k_min);
             assert!(*k <= k_max);
@@ -464,7 +464,7 @@ mod tests {
         let indexes = idx.hex_range_distances(k_min, k_max).unwrap();
 
         let mut indexes_resolutions: HashMap<H3Index, Vec<u32>> = HashMap::new();
-        for (dist, idx) in indexes.iter() {
+        for (dist, idx) in &indexes {
             indexes_resolutions
                 .entry(idx.h3index())
                 .and_modify(|v| v.push(*dist))
@@ -472,7 +472,7 @@ mod tests {
         }
 
         assert!(indexes.len() > 10);
-        for (k, index) in indexes.iter() {
+        for (k, index) in &indexes {
             assert!(index.is_valid());
             assert!(*k >= k_min);
             assert!(*k <= k_max);

--- a/h3ron/src/h3_direction.rs
+++ b/h3ron/src/h3_direction.rs
@@ -89,9 +89,8 @@ impl H3Direction {
         let ptr = index.h3index() as *const u64;
         let ptr = ptr as u64;
         let offset =
-            (H3_MAX_RESOLUTION.saturating_sub(target_resolution) * H3_PER_DIGIT_OFFSET) as u64;
-        let mask = H3_DIGIT_MASK as u64;
-        let dir = (ptr >> offset) & mask;
+            u64::from(H3_MAX_RESOLUTION.saturating_sub(target_resolution) * H3_PER_DIGIT_OFFSET);
+        let dir = (ptr >> offset) & u64::from(H3_DIGIT_MASK);
         Self::try_from(dir as u8)
     }
 }

--- a/h3ron/src/h3_direction.rs
+++ b/h3ron/src/h3_direction.rs
@@ -174,7 +174,7 @@ mod tests {
             if child == center_child {
                 continue;
             }
-            let edge = child.unidirectional_edge_to(&center_child).unwrap();
+            let edge = child.unidirectional_edge_to(center_child).unwrap();
             let direction = H3Direction::direction(&edge);
             assert_eq!(direction as usize, i);
         }

--- a/h3ron/src/h3_edge.rs
+++ b/h3ron/src/h3_edge.rs
@@ -221,10 +221,10 @@ impl Index for H3Edge {
     }
 
     fn validate(&self) -> Result<(), Error> {
-        if !self.is_edge_valid() {
-            Err(Error::InvalidH3Edge(self.h3index()))
-        } else {
+        if self.is_edge_valid() {
             Ok(())
+        } else {
+            Err(Error::InvalidH3Edge(self.h3index()))
         }
     }
 }

--- a/h3ron/src/h3_edge.rs
+++ b/h3ron/src/h3_edge.rs
@@ -43,7 +43,7 @@ impl TryFrom<u64> for H3Edge {
 impl H3Edge {
     /// Gets the unidirectional edge from `origin_cell` to `destination_cell`
     pub fn from_cells(origin_cell: H3Cell, destination_cell: H3Cell) -> Result<Self, Error> {
-        origin_cell.unidirectional_edge_to(&destination_cell)
+        origin_cell.unidirectional_edge_to(destination_cell)
     }
 
     pub fn is_edge_valid(&self) -> bool {
@@ -154,7 +154,7 @@ impl H3Edge {
         let edge_cells = self.cell_indexes_unchecked();
         edge_cells
             .destination
-            .unidirectional_edge_to_unchecked(&edge_cells.origin)
+            .unidirectional_edge_to_unchecked(edge_cells.origin)
     }
 
     /// Retrieves the corresponding edge in the reversed direction.
@@ -166,7 +166,7 @@ impl H3Edge {
         let edge_cells = self.cell_indexes()?;
         edge_cells
             .destination
-            .unidirectional_edge_to(&edge_cells.origin)
+            .unidirectional_edge_to(edge_cells.origin)
     }
 
     /// Retrieves the [`LineString`] which forms the boundary between

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -63,20 +63,19 @@ pub trait Index: Sized + PartialEq + FromH3Index {
     ///
     /// Use `get_parent` for validity check.
     fn get_parent_unchecked(&self, parent_resolution: u8) -> Self {
-        Self::new(unsafe { h3ron_h3_sys::h3ToParent(self.h3index(), parent_resolution as c_int) })
+        Self::new(unsafe {
+            h3ron_h3_sys::h3ToParent(self.h3index(), c_int::from(parent_resolution))
+        })
     }
 
     /// Retrieves all children of `self` at resolution `child_resolution`
     fn get_children(&self, child_resolution: u8) -> IndexVec<Self> {
+        let child_resolution = c_int::from(child_resolution);
         let mut index_vec = IndexVec::with_length(unsafe {
-            h3ron_h3_sys::maxH3ToChildrenSize(self.h3index(), c_int::from(child_resolution))
+            h3ron_h3_sys::maxH3ToChildrenSize(self.h3index(), child_resolution)
         } as usize);
         unsafe {
-            h3ron_h3_sys::h3ToChildren(
-                self.h3index(),
-                child_resolution as c_int,
-                index_vec.as_mut_ptr(),
-            );
+            h3ron_h3_sys::h3ToChildren(self.h3index(), child_resolution, index_vec.as_mut_ptr());
         }
         index_vec
     }

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -69,7 +69,7 @@ pub trait Index: Sized + PartialEq + FromH3Index {
     /// Retrieves all children of `self` at resolution `child_resolution`
     fn get_children(&self, child_resolution: u8) -> IndexVec<Self> {
         let mut index_vec = IndexVec::with_length(unsafe {
-            h3ron_h3_sys::maxH3ToChildrenSize(self.h3index(), child_resolution as c_int)
+            h3ron_h3_sys::maxH3ToChildrenSize(self.h3index(), c_int::from(child_resolution))
         } as usize);
         unsafe {
             h3ron_h3_sys::h3ToChildren(

--- a/h3ron/src/iter/edge.rs
+++ b/h3ron/src/iter/edge.rs
@@ -120,7 +120,7 @@ where
                 continue;
             }
 
-            let edge_result = last_cell.unidirectional_edge_to(&cell);
+            let edge_result = last_cell.unidirectional_edge_to(cell);
             self.last_cell = Some(cell);
             return Some(edge_result);
         }

--- a/h3ron/src/iter/edge.rs
+++ b/h3ron/src/iter/edge.rs
@@ -2,7 +2,7 @@ use crate::collections::indexvec::{IndexVec, UncheckedIter};
 use crate::{Error, H3Cell, H3Edge, Index};
 use std::borrow::Borrow;
 
-/// Creates H3Edges from cells while only requiring a single memory allocation
+/// Creates `H3Edges` from cells while only requiring a single memory allocation
 /// when the struct is created.
 pub struct H3EdgesBuilder {
     index_vec: IndexVec<H3Edge>,
@@ -30,7 +30,7 @@ impl H3EdgesBuilder {
             h3ron_h3_sys::getH3UnidirectionalEdgesFromHexagon(
                 cell.h3index(),
                 self.index_vec.as_mut_ptr(),
-            )
+            );
         };
         self.index_vec.iter()
     }
@@ -109,12 +109,11 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         for cell_item in self.iter.by_ref() {
             let cell = *cell_item.borrow();
-            let last_cell = match self.last_cell {
-                Some(last_cell) => last_cell,
-                None => {
-                    self.last_cell = Some(cell);
-                    continue;
-                }
+            let last_cell = if let Some(cell) = self.last_cell {
+                cell
+            } else {
+                self.last_cell = Some(cell);
+                continue;
             };
             if cell == last_cell {
                 // duplicate cell, skipping

--- a/h3ron/src/iter/kring.rs
+++ b/h3ron/src/iter/kring.rs
@@ -67,7 +67,7 @@ impl KRingBuilder {
                 self.k_max as c_int,
                 self.k_ring_indexes.as_mut_ptr(),
                 self.k_ring_distances.as_mut_ptr(),
-            )
+            );
         };
         self.rewind_iterator();
         self

--- a/h3ron/src/iter/neighbor.rs
+++ b/h3ron/src/iter/neighbor.rs
@@ -43,10 +43,8 @@ pub struct CellNeighborsIterator<'a, I, F, T> {
 impl<'a, I, F, T> Iterator for CellNeighborsIterator<'a, I, F, T>
 where
     I: Iterator,
-    I::Item: Borrow<H3Cell>,
-    I: 'a,
-    F: Fn(&H3Cell) -> Option<&'a T>,
-    F: 'a,
+    I::Item: Borrow<H3Cell> + 'a,
+    F: Fn(&H3Cell) -> Option<&'a T> + 'a,
     T: 'a,
 {
     type Item = NeighborCell<'a, T>;
@@ -102,10 +100,8 @@ pub fn neighbors_within_distance_window_or_default<'a, I, F, T>(
 ) -> CellNeighborsIterator<'a, I, F, T>
 where
     I: Iterator,
-    I::Item: Borrow<H3Cell>,
-    I: 'a,
-    F: Fn(&H3Cell) -> Option<&'a T>,
-    F: 'a,
+    I::Item: Borrow<H3Cell> + 'a,
+    F: Fn(&H3Cell) -> Option<&'a T> + 'a,
 {
     CellNeighborsIterator {
         cell_iter,
@@ -126,10 +122,8 @@ pub fn neighbors_within_distance_window<'a, I, F, T>(
 ) -> CellNeighborsIterator<'a, I, F, T>
 where
     I: Iterator,
-    I::Item: Borrow<H3Cell>,
-    I: 'a,
-    F: Fn(&H3Cell) -> Option<&'a T>,
-    F: 'a,
+    I::Item: Borrow<H3Cell> + 'a,
+    F: Fn(&H3Cell) -> Option<&'a T> + 'a,
 {
     neighbors_within_distance_window_or_default(cell_iter, get_cell_value_fn, k_min, k_max, None)
 }
@@ -143,10 +137,8 @@ pub fn neighbors_within_distance<'a, I, F, T>(
 ) -> CellNeighborsIterator<'a, I, F, T>
 where
     I: Iterator,
-    I::Item: Borrow<H3Cell>,
-    I: 'a,
-    F: Fn(&H3Cell) -> Option<&'a T>,
-    F: 'a,
+    I::Item: Borrow<H3Cell> + 'a,
+    F: Fn(&H3Cell) -> Option<&'a T> + 'a,
 {
     neighbors_within_distance_window_or_default(
         cell_iter,

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -134,7 +134,7 @@ pub fn polyfill(poly: &Polygon<f64>, h3_resolution: u8) -> IndexVec<H3Cell> {
             holes: holes.as_mut_ptr(),
         };
 
-        let num_hexagons = h3ron_h3_sys::maxPolyfillSize(&gp, h3_resolution as c_int);
+        let num_hexagons = h3ron_h3_sys::maxPolyfillSize(&gp, c_int::from(h3_resolution));
 
         // pre-allocate for the expected number of hexagons
         let mut index_vec = IndexVec::with_length(num_hexagons as usize);

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -54,7 +54,7 @@ pub mod to_h3;
 pub const H3_MIN_RESOLUTION: u8 = 0_u8;
 pub const H3_MAX_RESOLUTION: u8 = 15_u8;
 
-/// trait for types which can be created from an H3Index
+/// trait for types which can be created from an `H3Index`
 pub trait FromH3Index {
     fn from_h3index(h3index: H3Index) -> Self;
 }
@@ -113,7 +113,7 @@ pub fn max_polyfill_size(poly: &Polygon<f64>, h3_resolution: u8) -> usize {
             holes: holes.as_mut_ptr(),
         };
 
-        h3ron_h3_sys::maxPolyfillSize(&gp, h3_resolution as c_int) as usize
+        h3ron_h3_sys::maxPolyfillSize(&gp, c_int::from(h3_resolution)) as usize
     }
 }
 
@@ -139,7 +139,7 @@ pub fn polyfill(poly: &Polygon<f64>, h3_resolution: u8) -> IndexVec<H3Cell> {
         // pre-allocate for the expected number of hexagons
         let mut index_vec = IndexVec::with_length(num_hexagons as usize);
 
-        h3ron_h3_sys::polyfill(&gp, h3_resolution as c_int, index_vec.as_mut_ptr());
+        h3ron_h3_sys::polyfill(&gp, c_int::from(h3_resolution), index_vec.as_mut_ptr());
         index_vec
     }
 }
@@ -151,7 +151,7 @@ pub fn compact(cells: &[H3Cell]) -> IndexVec<H3Cell> {
     unsafe {
         // the following requires `repr(transparent)` on H3Cell
         let h3index_slice =
-            std::slice::from_raw_parts(cells.as_ptr() as *const H3Index, cells.len());
+            std::slice::from_raw_parts(cells.as_ptr().cast::<H3Index>(), cells.len());
         h3ron_h3_sys::compact(
             h3index_slice.as_ptr(),
             index_vec.as_mut_ptr(),
@@ -161,7 +161,7 @@ pub fn compact(cells: &[H3Cell]) -> IndexVec<H3Cell> {
     index_vec
 }
 
-/// maximum number of cells needed for the k_ring
+/// maximum number of cells needed for the `k_ring`
 #[inline]
 pub fn max_k_ring_size(k: u32) -> usize {
     unsafe { h3ron_h3_sys::maxKringSize(k as c_int) as usize }
@@ -194,6 +194,15 @@ fn line_between_cells_not_checked(start: H3Cell, end: H3Cell) -> Result<IndexVec
 }
 
 /// Line of h3 indexes connecting two indexes
+///
+/// # Arguments
+///
+/// * `start`- start cell
+/// * `end` - end cell
+///
+/// # Errors
+///
+/// The function can fail if `start` and `end` have different resolutions
 pub fn line_between_cells(start: H3Cell, end: H3Cell) -> Result<IndexVec<H3Cell>, Error> {
     check_same_resolution(start, end)?;
     line_between_cells_not_checked(start, end)
@@ -203,6 +212,10 @@ pub fn line_between_cells(start: H3Cell, end: H3Cell) -> Result<IndexVec<H3Cell>
 ///
 /// The returned cells are ordered sequentially, there are no
 /// duplicates caused by the start and endpoints of multiple line segments.
+///
+/// # Errors
+///
+/// The function may fail if invalid indexes are built from the given coordinates.
 pub fn line(linestring: &LineString<f64>, h3_resolution: u8) -> Result<IndexVec<H3Cell>, Error> {
     let mut cells_out = IndexVec::new();
     for coords in linestring.0.windows(2) {
@@ -247,6 +260,6 @@ mod tests {
             Coordinate::from((-20.74, 34.88)),
             Coordinate::from((-23.55, 48.92)),
         ]);
-        assert!(line(&ls, 5).unwrap().count() > 200)
+        assert!(line(&ls, 5).unwrap().count() > 200);
     }
 }

--- a/h3ron/src/to_geo.rs
+++ b/h3ron/src/to_geo.rs
@@ -93,7 +93,7 @@ impl ToAlignedLinkedPolygons for Vec<H3Cell> {
             cells_grouped
                 .entry(parent_cell)
                 .or_insert_with(Self::new)
-                .push(*cell)
+                .push(*cell);
         }
 
         let mut polygons = Vec::new();
@@ -163,7 +163,7 @@ pub fn to_linked_polygons(cells: &[H3Cell], smoothen: bool) -> Vec<Polygon<f64>>
         };
         // the following requires `repr(transparent)` on H3Cell
         let h3index_slice =
-            std::slice::from_raw_parts(cells.as_ptr() as *const H3Index, cells.len());
+            std::slice::from_raw_parts(cells.as_ptr().cast::<H3Index>(), cells.len());
         h3SetToLinkedGeo(
             h3index_slice.as_ptr(),
             h3index_slice.len() as c_int,
@@ -191,9 +191,9 @@ pub fn to_linked_polygons(cells: &[H3Cell], smoothen: bool) -> Vec<Polygon<f64>>
                 if coordinates.len() >= 3 {
                     let linestring = LineString::from(coordinates);
                     if linked_loop_i == 0 {
-                        exterior = Some(linestring)
+                        exterior = Some(linestring);
                     } else {
-                        interiors.push(linestring)
+                        interiors.push(linestring);
                     }
                 }
 

--- a/h3ron/src/to_h3.rs
+++ b/h3ron/src/to_h3.rs
@@ -27,7 +27,7 @@ impl ToH3Cells for Polygon<f64> {
 impl ToH3Cells for MultiPolygon<f64> {
     fn to_h3_cells(&self, h3_resolution: u8) -> Result<IndexVec<H3Cell>, Error> {
         let mut outvec = IndexVec::new();
-        for poly in self.0.iter() {
+        for poly in &self.0 {
             let mut thisvec = poly.to_h3_cells(h3_resolution)?;
             outvec.append(&mut thisvec);
         }
@@ -44,7 +44,7 @@ impl ToH3Cells for Point<f64> {
 impl ToH3Cells for MultiPoint<f64> {
     fn to_h3_cells(&self, h3_resolution: u8) -> Result<IndexVec<H3Cell>, Error> {
         let mut outvec = vec![];
-        for pt in self.0.iter() {
+        for pt in &self.0 {
             outvec.push(H3Cell::from_coordinate(&pt.0, h3_resolution)?.h3index());
         }
         outvec.try_into()
@@ -68,7 +68,7 @@ impl ToH3Cells for LineString<f64> {
 impl ToH3Cells for MultiLineString<f64> {
     fn to_h3_cells(&self, h3_resolution: u8) -> Result<IndexVec<H3Cell>, Error> {
         let mut outvec = IndexVec::new();
-        for ls in self.0.iter() {
+        for ls in &self.0 {
             let mut thisvec = ls.to_h3_cells(h3_resolution)?;
             outvec.append(&mut thisvec);
         }
@@ -97,7 +97,7 @@ impl ToH3Cells for Line<f64> {
 impl ToH3Cells for GeometryCollection<f64> {
     fn to_h3_cells(&self, h3_resolution: u8) -> Result<IndexVec<H3Cell>, Error> {
         let mut outvec = IndexVec::new();
-        for geom in self.0.iter() {
+        for geom in &self.0 {
             let mut thisvec = geom.to_h3_cells(h3_resolution)?;
             outvec.append(&mut thisvec);
         }


### PR DESCRIPTION
Some `pedantic` clippy changes.

Some breaking changes for `Copy` elements like `H3Cell` and `H3Edge` that don't need to be passed as references.
Also some breaking changes for `associated_index_distances` not needing its `self` parameter