### PR TITLE
remove rayon from hashbrown dep

### DIFF
--- a/h3ron/Cargo.toml
+++ b/h3ron/Cargo.toml
@@ -36,7 +36,7 @@ optional = true
 
 [dependencies.hashbrown]
 version = "0.11"
-features = ["rayon", "serde"]
+features = ["serde"]
 
 [dependencies.rayon]
 version = "1.5"


### PR DESCRIPTION
When trying to use h3ron v0.12.0 without any features, rayon still gets pulled in. This is because hasbrown now depends on it as a feature, but it appears it might be unnecessary?