### PR TITLE
Faillible directions

### DIFF
--- a/h3ron/src/collections/treemap/mod.rs
+++ b/h3ron/src/collections/treemap/mod.rs
@@ -33,9 +33,10 @@ where
     /// Please note the - for unsorted values faster - `from_iter_with_sort` method.
     fn from_iter<I: IntoIterator<Item = Q>>(iter: I) -> Self {
         Self {
-            treemap: RoaringTreemap::from_iter(
-                iter.into_iter().map(|c| c.borrow().h3index() as u64),
-            ),
+            treemap: iter
+                .into_iter()
+                .map(|c| c.borrow().h3index() as u64)
+                .collect(),
             phantom_data: Default::default(),
         }
     }

--- a/h3ron/src/directed_edge.rs
+++ b/h3ron/src/directed_edge.rs
@@ -54,8 +54,8 @@ impl H3DirectedEdge {
         let mut edge_length: f64 = 0.0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::getHexagonEdgeLengthAvgKm(c_int::from(resolution), &mut edge_length)
-        })?;
-        Ok(edge_length)
+        })
+        .map(|_| edge_length)
     }
 
     /// Gets the average length of an edge in meters at `resolution`.
@@ -64,8 +64,8 @@ impl H3DirectedEdge {
         let mut edge_length: f64 = 0.0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::getHexagonEdgeLengthAvgM(c_int::from(resolution), &mut edge_length)
-        })?;
-        Ok(edge_length)
+        })
+        .map(|_| edge_length)
     }
 
     /// The approximate distance between the centroids of two neighboring cells
@@ -74,9 +74,7 @@ impl H3DirectedEdge {
     /// Based on the approximate edge length. See [`H3DirectedEdge::cell_centroid_distance_m`] for a
     /// more exact variant of this function.
     pub fn cell_centroid_distance_avg_m_at_resolution(resolution: u8) -> Result<f64, Error> {
-        Ok(cell_centroid_distance_m_by_edge_length(
-            Self::edge_length_avg_m(resolution)?,
-        ))
+        Self::edge_length_avg_m(resolution).map(cell_centroid_distance_m_by_edge_length)
     }
 
     /// The approximate distance between the centroids of two neighboring cells
@@ -85,9 +83,8 @@ impl H3DirectedEdge {
     /// Based on the exact edge length. See [`H3DirectedEdge::cell_centroid_distance_avg_m_at_resolution`]
     /// for a resolution based variant.
     pub fn cell_centroid_distance_m(&self) -> Result<f64, Error> {
-        Ok(cell_centroid_distance_m_by_edge_length(
-            self.exact_length_m()?,
-        ))
+        self.exact_length_m()
+            .map(cell_centroid_distance_m_by_edge_length)
     }
 
     /// Retrieves the destination H3 Cell of `self`
@@ -98,8 +95,8 @@ impl H3DirectedEdge {
         let mut cell_h3index: H3Index = 0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::getDirectedEdgeDestination(self.h3index(), &mut cell_h3index)
-        })?;
-        Ok(H3Cell::new(cell_h3index))
+        })
+        .map(|_| H3Cell::new(cell_h3index))
     }
 
     /// Retrieves the origin H3 Cell of `self`
@@ -110,8 +107,8 @@ impl H3DirectedEdge {
         let mut cell_h3index: H3Index = 0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::getDirectedEdgeOrigin(self.h3index(), &mut cell_h3index)
-        })?;
-        Ok(H3Cell::new(cell_h3index))
+        })
+        .map(|_| H3Cell::new(cell_h3index))
     }
 
     /// Retrieves a `H3EdgeCells` of the origin and destination cell of the
@@ -124,10 +121,13 @@ impl H3DirectedEdge {
         unsafe {
             h3ron_h3_sys::directedEdgeToCells(self.h3index(), out.as_mut_ptr());
         }
-        Ok(H3EdgeCells {
+        let res = H3EdgeCells {
             origin: H3Cell::new(out[0]),
             destination: H3Cell::new(out[1]),
-        })
+        };
+        res.origin.validate()?;
+        res.destination.validate()?;
+        Ok(res)
     }
 
     /// Retrieves the corresponding edge in the reversed direction.
@@ -159,8 +159,8 @@ impl H3DirectedEdge {
         let mut length: f64 = 0.0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::exactEdgeLengthM(self.h3index(), &mut length)
-        })?;
-        Ok(length)
+        })
+        .map(|_| length)
     }
 
     /// Retrieves the exact length of `self` in kilometers
@@ -169,8 +169,8 @@ impl H3DirectedEdge {
         let mut length: f64 = 0.0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::exactEdgeLengthKm(self.h3index(), &mut length)
-        })?;
-        Ok(length)
+        })
+        .map(|_| length)
     }
 
     /// Retrieves the exact length of `self` in radians
@@ -179,8 +179,8 @@ impl H3DirectedEdge {
         let mut length: f64 = 0.0;
         Error::check_returncode(unsafe {
             h3ron_h3_sys::exactEdgeLengthRads(self.h3index(), &mut length)
-        })?;
-        Ok(length)
+        })
+        .map(|_| length)
     }
 }
 

--- a/h3ron/src/direction.rs
+++ b/h3ron/src/direction.rs
@@ -66,7 +66,9 @@ impl H3Direction {
     ///
     /// # Errors
     ///
-    /// May fail if the direction is invalid
+    /// May fail if the direction is invalid. This can be caused by trying to retrieve a direction for:
+    /// - an index of 0 resolution
+    /// - an invalid index
     pub fn direction_to_parent<I: Index>(index: &I) -> Result<Self, Error> {
         Self::direction_to_parent_resolution(index, index.resolution().saturating_sub(1))
     }
@@ -75,7 +77,9 @@ impl H3Direction {
     ///
     /// # Errors
     ///
-    /// May fail if the direction is invalid
+    /// May fail if the direction is invalid. This can be caused by trying to retrieve a direction for:
+    /// - an index of 0 resolution
+    /// - an invalid index
     pub fn direction<I: Index>(index: &I) -> Result<Self, Error> {
         Self::direction_to_parent_resolution(index, index.resolution())
     }
@@ -164,9 +168,9 @@ mod tests {
         assert_eq!(cell.resolution(), 5);
         let direction = H3Direction::direction_to_parent_resolution(&cell, 4).unwrap();
         assert_eq!(direction, H3Direction::JkAxesDigit);
-        let direction = H3Direction::direction_to_parent(&cell);
+        let direction = H3Direction::direction_to_parent(&cell).unwrap();
         assert_eq!(direction, H3Direction::JkAxesDigit);
-        let direction = H3Direction::direction(&cell);
+        let direction = H3Direction::direction(&cell).unwrap();
         assert_eq!(direction, H3Direction::IjAxesDigit);
     }
 
@@ -185,14 +189,14 @@ mod tests {
         assert_eq!(cell.resolution(), 5);
         H3Direction::direction_to_parent_resolution(&cell, 6).unwrap();
     }
-
     #[test]
-    fn works_with_res_0() {
-        let cell = H3Cell::try_from(0x8518607bfffffff).unwrap();
-        let cell = cell.get_parent(0).unwrap();
+    fn can_fail_with_res_0() {
+        let cell = H3Cell::try_from(0x801ffffffffffff).unwrap();
+        let cell_2 = H3Cell::try_from(0x805ffffffffffff).unwrap();
         assert_eq!(cell.resolution(), 0);
-        let direction = H3Direction::direction_to_parent(&cell);
-        assert_eq!(direction, H3Direction::IAxesDigit);
+        assert_eq!(cell_2.resolution(), 0);
+        assert!(H3Direction::direction(&cell).is_err());
+        assert!(H3Direction::direction(&cell_2).is_err());
     }
 
     #[test]
@@ -200,7 +204,7 @@ mod tests {
         let cell = H3Cell::try_from(0x8518607bfffffff).unwrap();
         let children = cell.get_children(cell.resolution() + 1).unwrap();
         for (i, child) in children.iter().enumerate() {
-            let direction = H3Direction::direction(&child);
+            let direction = H3Direction::direction(&child).unwrap();
             assert_eq!(direction as usize, i);
         }
     }
@@ -215,7 +219,7 @@ mod tests {
                 continue;
             }
             let edge = child.directed_edge_to(center_child).unwrap();
-            let direction = H3Direction::direction(&edge);
+            let direction = H3Direction::direction(&edge).unwrap();
             assert_eq!(direction as usize, i);
         }
     }

--- a/h3ron/src/direction.rs
+++ b/h3ron/src/direction.rs
@@ -63,13 +63,21 @@ impl TryFrom<u8> for H3Direction {
 
 impl H3Direction {
     /// Retrieves the H3 Direction of the `index` relative to its direct parent
-    pub fn direction_to_parent<I: Index>(index: &I) -> Self {
-        Self::direction_to_parent_resolution(index, index.resolution().saturating_sub(1)).unwrap()
+    ///
+    /// # Errors
+    ///
+    /// May fail if the direction is invalid
+    pub fn direction_to_parent<I: Index>(index: &I) -> Result<Self, Error> {
+        Self::direction_to_parent_resolution(index, index.resolution().saturating_sub(1))
     }
 
     /// Retrieves the H3 Direction of the `index`
-    pub fn direction<I: Index>(index: &I) -> Self {
-        Self::direction_to_parent_resolution(index, index.resolution()).unwrap()
+    ///
+    /// # Errors
+    ///
+    /// May fail if the direction is invalid
+    pub fn direction<I: Index>(index: &I) -> Result<Self, Error> {
+        Self::direction_to_parent_resolution(index, index.resolution())
     }
 
     /// Retrieves the H3 Direction of the `index` relative to its parent at `target_resolution`.

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -27,6 +27,11 @@ pub trait Index: Sized + PartialEq + FromH3Index {
 
     /// Retrieves the direction of the current index
     fn direction(&self) -> H3Direction {
+        H3Direction::direction(self).unwrap()
+    }
+
+    /// Retrieves the direction of the current index
+    fn direction_checked(&self) -> Result<H3Direction, Error> {
         H3Direction::direction(self)
     }
 

--- a/h3ron/src/index.rs
+++ b/h3ron/src/index.rs
@@ -26,11 +26,19 @@ pub trait Index: Sized + PartialEq + FromH3Index {
     }
 
     /// Retrieves the direction of the current index
+    ///
+    /// # Panics
+    ///
+    /// May panic if `self` is invalid or has a `resolution` of 0
     fn direction(&self) -> H3Direction {
         H3Direction::direction(self).unwrap()
     }
 
     /// Retrieves the direction of the current index
+    ///
+    /// # Errors
+    ///
+    /// May fail if `self` is invalid or has a `resolution` of 0
     fn direction_checked(&self) -> Result<H3Direction, Error> {
         H3Direction::direction(self)
     }

--- a/h3ron/src/lib.rs
+++ b/h3ron/src/lib.rs
@@ -9,16 +9,7 @@
 //! * **roaring**: Enables `collections::H3Treemap` based on the `roaring` crate.
 //! * **io**: Convenience serialization helpers of the `h3ron::io` module. These are not really related to h3, but helpful for utilities
 //! during development.
-#![warn(
-    clippy::all,
-    clippy::correctness,
-    clippy::suspicious,
-    clippy::style,
-    clippy::complexity,
-    clippy::perf,
-    clippy::nursery,
-    nonstandard_style
-)]
+#![warn(clippy::nursery, nonstandard_style)]
 #![allow(clippy::redundant_pub_crate)]
 use std::iter::Iterator;
 use std::os::raw::c_int;


### PR DESCRIPTION
I have a use case where calling `H3Cell::direction` panics with an invalid direction of 7.
This means that there should be a faillible API for directions because it can fail on resolution 0.

I also improved some code a bit and removed redundant clippy configuration I added a while ago